### PR TITLE
Fixes #3035 : Add a patch to fusion inventory to handle service pack on Suse systems

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -51,6 +51,7 @@ localdepends: ./initial-promises ./files ./fusioninventory-agent ./cfengine-sour
 	$(WGET) -O $(TMP_DIR)/fusion.tgz http://www.normation.com/tarball/FusionInventory-Agent-$(FUSION_RELEASE).tar.gz
 	tar zvxf $(TMP_DIR)/fusion.tgz -C $(TMP_DIR)
 	mv $(TMP_DIR)/FusionInventory-Agent-$(FUSION_RELEASE) ./fusioninventory-agent
+	$(PATCH) -d ./fusioninventory-agent -p1 < ./SuSE_service_pack.patch
 
 ./files: /usr/bin/wget
 	mkdir ./files

--- a/rudder-agent/SOURCES/SuSE_service_pack.patch
+++ b/rudder-agent/SOURCES/SuSE_service_pack.patch
@@ -1,0 +1,46 @@
+From 4526c3be3db95cf593023660a91d2bd9d82ef0cf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Vincent=20Membr=C3=A9?= <vincent.membre@normation.com>
+Date: Thu, 29 Nov 2012 16:29:53 +0100
+Subject: [PATCH] Add SuSE.pm to handle Service Pack values of SLES
+
+---
+ .../Task/Inventory/Input/Linux/Distro/SuSE.pm      |   27 ++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+ create mode 100644 lib/FusionInventory/Agent/Task/Inventory/Input/Linux/Distro/SuSE.pm
+
+diff --git a/lib/FusionInventory/Agent/Task/Inventory/Input/Linux/Distro/SuSE.pm b/lib/FusionInventory/Agent/Task/Inventory/Input/Linux/Distro/SuSE.pm
+new file mode 100644
+index 0000000..cdaa6db
+--- /dev/null
++++ b/lib/FusionInventory/Agent/Task/Inventory/Input/Linux/Distro/SuSE.pm
+@@ -0,0 +1,27 @@
++package FusionInventory::Agent::Task::Inventory::Input::Linux::Distro::SuSE;
++
++use strict;
++use warnings;
++
++use English qw(-no_match_vars);
++use FusionInventory::Agent::Tools;
++
++# This module is used to detect SuSE's service pack level
++
++sub isEnabled {
++    return canRead('/etc/SuSE-release');
++}
++
++sub doInventory {
++    my (%params) = @_;
++    my $inventory = $params{inventory};
++
++    my $service_pack  = getFirstMatch(
++            file    => '/etc/SuSE-release',
++            pattern => qr/^PATCHLEVEL = ([0-9]+)/
++        );
++    $inventory->setOperatingSystem({ SERVICE_PACK => $service_pack});
++
++}
++
++1;
+-- 
+1.7.10.4
+


### PR DESCRIPTION
this pull request is related to http://www.rudder-project.org/redmine/issues/3035

It applies a patch to fusion inventory to handle Suse service pack.

It had been tested on a SLES 11 SP1 both having and not having lsb_release installed.

Having lsb_release cause fusion inventory to not process service pack value, the patch fixed this.
