### PR TITLE
Fixes #3075 - Hide output of commands used to check LDAP indexes and content of logback.xml during migration in rudder-upgrade.script

### DIFF
--- a/rudder-inventory-ldap/SPECS/rudder-inventory-ldap.spec
+++ b/rudder-inventory-ldap/SPECS/rudder-inventory-ldap.spec
@@ -294,7 +294,7 @@ SLAPD_ACTUAL_INDEXES=$(mktemp)
 if [ -r /opt/rudder/etc/openldap/slapd.conf -a -e /var/rudder/ldap/openldap-data/id2entry.bdb ]; then
 	grep ^index /opt/rudder/etc/openldap/slapd.conf | sed 's/\s\+/\t/g' | cut -f2 | sed 's/,/\n/g' | sort > ${SLAPD_DEFINED_INDEXES}
 	ls  /var/rudder/ldap/openldap-data/*.bdb | xargs -n 1 -I{} basename {} .bdb | sort | egrep -v '^(dn2id|id2entry)' > ${SLAPD_ACTUAL_INDEXES}
-	if ! diff ${SLAPD_DEFINED_INDEXES} ${SLAPD_ACTUAL_INDEXES}; then
+	if ! diff ${SLAPD_DEFINED_INDEXES} ${SLAPD_ACTUAL_INDEXES} > /dev/null; then
 		echo "OpenLDAP indexes are not up to date, reindexing..."
 		/etc/init.d/slapd stop
 		/opt/rudder/sbin/slapindex

--- a/rudder-inventory-ldap/debian/postinst
+++ b/rudder-inventory-ldap/debian/postinst
@@ -123,7 +123,7 @@ case "$1" in
 		if [ -r /opt/rudder/etc/openldap/slapd.conf -a -e /var/rudder/ldap/openldap-data/id2entry.bdb ]; then
 			grep ^index /opt/rudder/etc/openldap/slapd.conf | sed 's/\s\+/\t/g' | cut -f2 | sed 's/,/\n/g' | sort > ${SLAPD_DEFINED_INDEXES}
 			ls  /var/rudder/ldap/openldap-data/*.bdb | xargs -n 1 -I{} basename {} .bdb | sort | egrep -v '^(dn2id|id2entry)' > ${SLAPD_ACTUAL_INDEXES}
-			if ! diff ${SLAPD_DEFINED_INDEXES} ${SLAPD_ACTUAL_INDEXES}; then
+			if ! diff ${SLAPD_DEFINED_INDEXES} ${SLAPD_ACTUAL_INDEXES} > /dev/null; then
 				echo "OpenLDAP indexes are not up to date, reindexing..."
 				invoke-rc.d slapd stop
 				/opt/rudder/sbin/slapindex

--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -561,7 +561,7 @@ if [ ${CHECK_BASEURL_ATTR} -ge 1 ]; then
 fi
 
 # - 2.4.0 : Update logback.xml in order to have information about name historization
-if ! cat /opt/rudder/etc/logback.xml | perl -p0e 's/\n//g' | perl -p0e 's/<!--.(?:(?!-->).)*-->//g' | perl -p0e 's/> *</></g' | grep '<logger name="historization" level="info" additivity="false"><appender-ref ref="OPSLOG" /><appender-ref ref="STDOUT" /></logger>'
+if ! cat /opt/rudder/etc/logback.xml | perl -p0e 's/\n//g' | perl -p0e 's/<!--.(?:(?!-->).)*-->//g' | perl -p0e 's/> *</></g' | grep '<logger name="historization" level="info" additivity="false"><appender-ref ref="OPSLOG" /><appender-ref ref="STDOUT" /></logger>' > /dev/null
 then
     sed -i 's%^ *</configuration>%   <logger name="historization" level="info" additivity="false">\n     <appender-ref ref="OPSLOG" />\n     <!-- comment the following appender if you dont want to have logs about report in both stdout and opslog -->\n     <appender-ref ref="STDOUT" />\n   </logger>\n </configuration>%' /opt/rudder/etc/logback.xml
 fi


### PR DESCRIPTION
Fixes #3075 - Hide output of commands used to check LDAP indexes and content of logback.xml during migration in rudder-upgrade.script
