### PR TITLE
Fixes #3176: Change every rsyslog init.d invocation to restart instead o...

### DIFF
--- a/rudder-inventory-endpoint/debian/postinst
+++ b/rudder-inventory-endpoint/debian/postinst
@@ -20,7 +20,7 @@ set -e
 
 case "$1" in
     configure)
-		invoke-rc.d rsyslog reload
+		invoke-rc.d rsyslog restart
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/rudder-reports/debian/postinst
+++ b/rudder-reports/debian/postinst
@@ -20,7 +20,7 @@ set -e
 
 case "$1" in
     configure)
-		invoke-rc.d rsyslog reload
+		invoke-rc.d rsyslog restart
   #Check if postgresql is started
   /etc/init.d/postgresql status > /dev/null
   if [ $? -ne 0 ]

--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -19,8 +19,8 @@ set -e
 
 case "$1" in
     configure)
-		echo "Reloading syslog"
-		invoke-rc.d rsyslog reload
+		echo "Restarting syslog"
+		invoke-rc.d rsyslog restart
   /etc/init.d/apache2 stop
   a2dissite default
   a2enmod dav_fs


### PR DESCRIPTION
...f reload, to prevent Debian Wheezy from failing

To be merged in Rudder 2.4 branch.

See http://www.rudder-project.org/redmine/issues/3176
