### PR TITLE
Fixes #3180: don't list /var/cfengine/inputs as a dir we control

### DIFF
--- a/rudder-agent/debian/dirs
+++ b/rudder-agent/debian/dirs
@@ -2,6 +2,5 @@ opt/rudder
 var/rudder/cfengine-community
 var/rudder/cfengine-community/inputs
 var/rudder/cfengine-community/bin
-var/cfengine/inputs
 opt/rudder/etc
 var/rudder/tmp


### PR DESCRIPTION
Fix for http://www.rudder-project.org/redmine/issues/3180
