### PR TITLE
Fixes #3209: add missing mkdir for /etc/cron.d on RPM packages

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -153,6 +153,7 @@ install -m 755 %{SOURCE1} %{buildroot}/etc/init.d/rudder-agent
 install -m 644 %{SOURCE2} %{buildroot}/etc/default/rudder-agent
 
 # Cron
+mkdir -p %{buildroot}/etc/cron.d
 install -m 644 %{SOURCE5} %{buildroot}/etc/cron.d/rudder-agent
 
 # Initial promises


### PR DESCRIPTION
Fix for http://www.rudder-project.org/redmine/issues/3209
