### PR TITLE
Fixes #3374 - Add migration script to change system group name and descriptions

### DIFF
--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -66,6 +66,7 @@ set -e
 # - 2.5.0 : Migration DB schema to add gitcommit table, to link a git commit to a modification
 # - 2.5.0 : Migration DB schema to add modificationid column to eventLog table
 # - 2.5.0 : Update logback.xml in order to have information about non compliant reports
+# - 2.6.0 : Migration LDAP modify entries about System groups
 #####################################################################################
 
 # Some variables
@@ -652,3 +653,8 @@ rudder.batch.databasecleaner.runtime.day=sunday"
 
 # For every upgrade, we force the root server to run a new inventory on the next CFEngine run
 touch /opt/rudder/etc/force_inventory
+
+# - 2.6.0 : Migration LDAP modify entries about System groups
+echo "Modifying system group entries in LDAP if necessary..."
+/opt/rudder/bin/ldapmodify -x -D ${LDAP_USER} -w ${LDAP_PASSWORD} -H ldap://localhost -f ${RUDDER_UPGRADE_TOOLS}/rudder-upgrade-modify-system-group-entries.ldif
+echo "OK"

--- a/rudder-webapp/SOURCES/rudder-upgrade-modify-system-group-entries.ldif
+++ b/rudder-webapp/SOURCES/rudder-upgrade-modify-system-group-entries.ldif
@@ -1,0 +1,59 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+################################################################################
+
+# LDIF to migrate system groups entries
+
+# Entry about system group
+dn: groupCategoryId=SystemGroups,groupCategoryId=GroupRoot,ou=Rudder,cn=rudder-configuration
+changetype: modify
+replace: cn
+cn: System groups
+
+# System group entry about policy server
+dn: ruleTarget=policyServer:root,groupCategoryId=SystemGroups,groupCategoryId=GroupRoot,ou=Rudder,cn=rudder-configuration
+changetype: modify
+replace: description
+description: Only the root policy server
+
+# System group entry about all nodes
+dn: ruleTarget=special:all,groupCategoryId=SystemGroups,groupCategoryId=GroupRoot,ou=Rudder,cn=rudder-configuration
+changetype: modify
+replace: cn
+cn: All nodes
+-
+replace: description
+description: All nodes known by Rudder (including Rudder policy servers)
+
+# System group entry about all nodes except policy server(s)
+dn: ruleTarget=special:all_exceptPolicyServers,groupCategoryId=SystemGroups,groupCategoryId=GroupRoot,ou=Rudder,cn=rudder-configuration
+changetype: modify
+replace: cn
+cn: All managed nodes
+-
+replace: description
+description: All nodes known by Rudder (excluding Rudder policy servers)
+
+# System group entry about all connected nodes to root policy server
+dn: nodeGroupId=hasPolicyServer-root,groupCategoryId=SystemGroups,groupCategoryId=GroupRoot,ou=Rudder,cn=rudder-configuration
+changetype: modify
+replace: cn
+cn: All nodes managed by root policy server
+-
+replace: description
+description: All nodes known by Rudder directly connected to the root server
+

--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -169,6 +169,7 @@ cp %{_sourcedir}/rudder-sources/rudder/rudder-core/src/main/resources/Migration/
 cp %{_sourcedir}/rudder-sources/rudder/rudder-core/src/main/resources/Migration/dbMigration-2.4-2.5-git-commit.sql %{buildroot}%{rudderdir}/share/upgrade-tools/
 cp %{_sourcedir}/rudder-sources/rudder/rudder-core/src/main/resources/Migration/dbMigration-2.4-2.5-add-modification-id-to-EventLog.sql %{buildroot}%{rudderdir}/share/upgrade-tools/
 cp %{_sourcedir}/rudder-upgrade-LDAP-schema-2.3-2.4-add-entries.ldif %{buildroot}%{rudderdir}/share/upgrade-tools/
+cp %{_sourcedir}/rudder-upgrade-modify-system-group-entries.ldif %{buildroot}%{rudderdir}/share/upgrade-tools/
 
 cp %{SOURCE5} %{buildroot}%{rudderdir}/bin/
 

--- a/rudder-webapp/debian/rules
+++ b/rudder-webapp/debian/rules
@@ -97,6 +97,7 @@ binary-arch: install
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-core/src/main/resources/Migration/ dbMigration-2.4-2.5-git-commit.sql /opt/rudder/share/upgrade-tools/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-core/src/main/resources/Migration/ dbMigration-2.4-2.5-add-modification-id-to-EventLog.sql /opt/rudder/share/upgrade-tools/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-upgrade-LDAP-schema-2.3-2.4-add-entries.ldif /opt/rudder/share/upgrade-tools/
+	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-upgrade-modify-system-group-entries.ldif /opt/rudder/share/upgrade-tools/
 
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-upgrade /opt/rudder/bin/
 


### PR DESCRIPTION
Fixes #3374 - Add migration script to change system group name and descriptions
