### PR TITLE
Fixes #3419: Use OpenJDK 7 JRE headless instead of regular one to reduce...

### DIFF
--- a/rudder-jetty/debian/control
+++ b/rudder-jetty/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.rudder-project.org
 
 Package: rudder-jetty
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, sun-java6-jre (>=6) | java7-runtime, rudder-inventory-ldap
+Depends: ${shlibs:Depends}, ${misc:Depends}, sun-java6-jre (>=6) | java7-runtime-headless, rudder-inventory-ldap
 Description: Configuration management and audit tool - Jetty application server
  Rudder is an open source configuration management and audit solution.
  .


### PR DESCRIPTION
... dependencies

To be merged in 2.4

Ticket: http://www.rudder-project.org/redmine/issues/3419
