### PR TITLE
Fixes #3586 - Remove dependencies for tokyocabinet if the OS is not CentOS 6 or later

### DIFF
--- a/rudder-agent/SOURCES/filter-reqs-without-tokyocabinet.pl
+++ b/rudder-agent/SOURCES/filter-reqs-without-tokyocabinet.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/perl -w
+use strict;
+use IPC::Open2;
+
+# This will run the original find-requires script
+# and then remove requirements we don't want
+open2(\*IN, \*OUT, @ARGV);
+print OUT while (<STDIN>);
+close(OUT);
+my $list = join('', <IN>);
+
+# Apply our exclude filters
+$list =~ s/^perl\(.*?$//mg;
+$list =~ s/^perl .*?$//mg;
+$list =~ s/^\/opt\/rudder\/bin\/perl.*?$//mg;
+$list =~ s/^.*tokyocabinet.*?$//mg;
+
+print $list;

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -65,7 +65,11 @@ Source6: rudder.conf
 AutoProv: 0
 %global _use_internal_dependency_generator 0
 %global __find_requires_orig %{__find_requires}
+%if 0%{?rhel} && 0%{?rhel} >= 6
 %define __find_requires %{_sourcedir}/filter-reqs.pl %{__find_requires_orig}
+%else
+%define __find_requires %{_sourcedir}/filter-reqs-without-tokyocabinet.pl %{__find_requires_orig}
+%endif
 %global __find_provides_orig %{__find_provides}
 %define __find_provides %{_sourcedir}/filter-reqs.pl %{__find_provides_orig}
 


### PR DESCRIPTION
Fixes #3586 - Remove dependencies for tokyocabinet if the OS is not CentOS 6 or later
