### PR TITLE
Fixes #3532: Prevent a HTML leak in syslog due to a CFEngine bug

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -36,6 +36,7 @@ localdepends: ./initial-promises ./files ./fusioninventory-agent ./tokyocabinet-
 	tar xvzf $(TMP_DIR)/cfengine.tgz -C $(TMP_DIR)
 	mv $(TMP_DIR)/cfengine-$(CFENGINE_RELEASE) ./cfengine-source
 	$(PATCH) -d ./cfengine-source -p1 < ./split_dist_evaluation.patch
+	$(PATCH) -d ./cfengine-source -p1 < ./html_leak_in_syslog.patch
 
 ./tokyocabinet-source: /usr/bin/wget
 	# Original URL: http://fallabs.com/tokyocabinet/tokyocabinet-${TOKYOCABINET_RELEASE}.tar.gz

--- a/rudder-agent/SOURCES/html_leak_in_syslog.patch
+++ b/rudder-agent/SOURCES/html_leak_in_syslog.patch
@@ -1,0 +1,135 @@
+diff --git a/src/cf-execd.c b/src/cf-execd.c
+index 21097ad..b829ef4 100644
+--- a/src/cf-execd.c
++++ b/src/cf-execd.c
+@@ -459,7 +459,7 @@ void StartServer(Policy *policy, ExecConfig *config, const ReportContext *report
+ 
+     if (!NO_FORK)
+     {
+-        ActAsDaemon(0);
++        ActAsDaemon(0, report_context);
+     }
+ 
+ #endif /* NOT MINGW */
+diff --git a/src/cf-serverd-functions.c b/src/cf-serverd-functions.c
+index 3bc0578..b72a7dd 100755
+--- a/src/cf-serverd-functions.c
++++ b/src/cf-serverd-functions.c
+@@ -272,7 +272,7 @@ void StartServer(Policy *policy, GenericAgentConfig config, const ReportContext
+ 
+     if (!NO_FORK)
+     {
+-        ActAsDaemon(sd);
++        ActAsDaemon(sd, report_context);
+     }
+ 
+ #endif /* NOT MINGW */
+diff --git a/src/env_monitor.c b/src/env_monitor.c
+index 4cacc3c..6c9b5ed 100644
+--- a/src/env_monitor.c
++++ b/src/env_monitor.c
+@@ -261,7 +261,7 @@ void MonitorStartServer(const Policy *policy, const ReportContext *report_contex
+ 
+     if (!NO_FORK)
+     {
+-        ActAsDaemon(0);
++        ActAsDaemon(0, report_context);
+     }
+ 
+ #endif /* NOT MINGW */
+diff --git a/src/exec_tools.c b/src/exec_tools.c
+index a614e29..41873de 100644
+--- a/src/exec_tools.c
++++ b/src/exec_tools.c
+@@ -115,9 +115,11 @@ int GetExecOutput(char *command, char *buffer, int useshell)
+ 
+ /**********************************************************************/
+ 
+-void ActAsDaemon(int preserve)
++void ActAsDaemon(int preserve, const ReportContext *report_context)
+ {
+     int fd, maxfd;
++    int preserve_fd[REPORT_OUTPUT_TYPE_MAX+1];
++    bool close_fd;
+ 
+ #ifdef HAVE_SETSID
+     setsid();
+@@ -161,9 +163,33 @@ void ActAsDaemon(int preserve)
+ # endif
+ #endif
+ 
++    // build an array of file descriptors we need to preserve
++    for (size_t i = 0; i < REPORT_OUTPUT_TYPE_MAX; i++)
++    {
++        if (report_context->report_writers[i])
++        {
++            preserve_fd[i] = WriterFD(report_context->report_writers[i]);
++        }
++        else
++        {
++            preserve_fd[i] = 0;
++        }
++    }
++    preserve_fd[REPORT_OUTPUT_TYPE_MAX] = preserve;
++
+     for (fd = STDERR_FILENO + 1; fd < maxfd; ++fd)
+     {
+-        if (fd != preserve)
++        close_fd = true;
++
++        for (int i = 0; i < sizeof(preserve_fd); i++)
++        {
++            if (fd == preserve_fd[i])
++            {
++                close_fd = false;
++            }
++        }
++
++        if (close_fd)
+         {
+             close(fd);
+         }
+diff --git a/src/prototypes3.h b/src/prototypes3.h
+index e0cee12..9a4bc1b 100644
+--- a/src/prototypes3.h
++++ b/src/prototypes3.h
+@@ -258,7 +258,7 @@ void SummarizePerPromiseCompliance(int xml, int html, int csv, int embed, char *
+ int IsExecutable(const char *file);
+ int ShellCommandReturnsZero(const char *comm, int useshell);
+ int GetExecOutput(char *command, char *buffer, int useshell);
+-void ActAsDaemon(int preserve);
++void ActAsDaemon(int preserve, const ReportContext *report_context);
+ char *ShEscapeCommand(char *s);
+ char **ArgSplitCommand(const char *comm);
+ void ArgFree(char **args);
+diff --git a/src/writer.c b/src/writer.c
+index c4e79a0..ee31359 100644
+--- a/src/writer.c
++++ b/src/writer.c
+@@ -256,3 +256,13 @@ FILE *FileWriterDetach(Writer *writer)
+     free(writer);
+     return file;
+ }
++
++int WriterFD(Writer *writer)
++{
++    if (writer->type != WT_FILE)
++    {
++        return 0;
++    }
++    FILE *file = writer->file;
++    return fileno(file);
++}
+diff --git a/src/writer.h b/src/writer.h
+index 49123a7..360fa5e 100644
+--- a/src/writer.h
++++ b/src/writer.h
+@@ -59,4 +59,7 @@
+ /* Returns the open file and destroys itself */
+ FILE *FileWriterDetach(Writer *writer);
+ 
++/* Returns the open file descriptor for a FileWriter, otherwise 0 */
++int WriterFD(Writer *writer);
++
+ #endif
+


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/3532

To be merged in the 2.6 branch
