### PR TITLE
Fixes #3633 - Prevent rudder-agent postinst to chmod nonexistent files in /var/rudder/cfengine-community/ppkeys

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -238,7 +238,9 @@ CFRUDDER_FIRST_INSTALL=0
 echo "Making sure that the permissions on the CFEngine key directory are correct..."
 if [ -d %{ruddervardir}/cfengine-community/ppkeys ]; then
 chmod 700 %{ruddervardir}/cfengine-community/ppkeys
-chmod 600 %{ruddervardir}/cfengine-community/ppkeys/*
+  if [ `ls %{ruddervardir}/cfengine-community/ppkeys | wc -l` -gt 0 ]; then
+    chmod 600 %{ruddervardir}/cfengine-community/ppkeys/*
+  fi
 fi
 
 # Do this at first install

--- a/rudder-agent/debian/postinst
+++ b/rudder-agent/debian/postinst
@@ -27,7 +27,9 @@ case "$1" in
 		echo "Making sure that the permissions on the CFEngine key directory are correct..."
     if [ -d /var/rudder/cfengine-community/ppkeys ]; then
 		chmod 700 /var/rudder/cfengine-community/ppkeys
-		chmod 600 /var/rudder/cfengine-community/ppkeys/*
+		if [ `ls /var/rudder/cfengine-community/ppkeys | wc -l` -gt 0 ]; then
+			chmod 600 /var/rudder/cfengine-community/ppkeys/*
+		fi
     fi
 
 		# Copy new binaries to workdir, make sure daemons are stopped first


### PR DESCRIPTION
Fixes #3633 - Prevent rudder-agent postinst to chmod nonexistent files in /var/rudder/cfengine-community/ppkeys
