### PR TITLE
Fixes #3648, #3649: Add CentOS 3 / RHEL 3 support to rudder-agent

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -22,7 +22,7 @@ RUDDER_VERSION_TO_PACKAGE = <put Rudder version or version-snapshot here>
 CFENGINE_RELEASE = 3.4.4
 FUSION_RELEASE = 2.2.2
 TOKYOCABINET_RELEASE = 1.4.48
-TMP_DIR := $(shell mktemp -dq)
+TMP_DIR := $(shell mktemp -dq /tmp/rudder.XXXXXX)
 WGET := $(if $(PROXY), http_proxy=$(PROXY) ftp_proxy=$(PROXY)) /usr/bin/wget
 PATCH := /usr/bin/patch
 FIND := /usr/bin/find
@@ -52,7 +52,8 @@ localdepends: ./initial-promises ./files ./fusioninventory-agent ./tokyocabinet-
 	mv rudder-sources-*/ rudder-sources/
 
 ./initial-promises: ./rudder-sources
-	cp -aT ./rudder-sources/rudder-techniques/initial-promises/node-server/ ./initial-promises/
+	rm -rf ./initial-promises/
+	cp -a ./rudder-sources/rudder-techniques/initial-promises/node-server/ ./initial-promises/
 
 ./fusioninventory-agent: /usr/bin/wget
 	#Original URL: http://search.cpan.org/CPAN/authors/id/F/FU/FUSINV/FusionInventory-Agent-$(FUSION_RELEASE).tar.gz
@@ -61,7 +62,7 @@ localdepends: ./initial-promises ./files ./fusioninventory-agent ./tokyocabinet-
 	mv $(TMP_DIR)/FusionInventory-Agent-$(FUSION_RELEASE) ./fusioninventory-agent
 	$(PATCH) -d ./fusioninventory-agent -p1 < ./SuSE_service_pack.patch
 	# Fix a lsusb invocation that crashes some SLES machines
-	$(FIND) ./fusioninventory-agent -iname "USB.pm" -delete
+	$(FIND) ./fusioninventory-agent -iname "USB.pm" -exec rm "{}" \;
 
 ./files: /usr/bin/wget
 	mkdir ./files

--- a/rudder-agent/SOURCES/perl-prepare.sh
+++ b/rudder-agent/SOURCES/perl-prepare.sh
@@ -32,6 +32,8 @@ if [ ! -f 'perl-prepare.sh' ]; then
     fi
 fi
 
+source ../../../scripts/detect_os.sh
+
 ROOT="$PWD/.."
 MAKE="make"
 TMP="$PWD/tmp"
@@ -124,6 +126,11 @@ archive=`ls $FILEDIR/App-cpanminus-*.tar.gz`
 echo $archive
 gunzip < $archive | tar xvf -
 CPANM=$BUILDDIR/App-cpanminus-1.0004/bin/cpanm
+
+# If we are ona RHEL 3, remove unwanted arguments to wget
+if [ "${OSVERSION}" -eq 3 -a "z${OS}" == "zRHEL" ]; then
+	sed -i "s/--retry-connrefused //" $BUILDDIR/App-cpanminus-1.0004/bin/cpanm
+fi
 
 installMod "URI"
 installMod "HTML::Tagset"


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/3649

To be merged in the 2.6 branch
