### PR TITLE
Fixes #3678 - Fix wrong instruction of cp for SLES 10

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -53,7 +53,7 @@ localdepends: ./initial-promises ./files ./fusioninventory-agent ./tokyocabinet-
 
 ./initial-promises: ./rudder-sources
 	rm -rf ./initial-promises/
-	cp -a ./rudder-sources/rudder-techniques/initial-promises/node-server/ ./initial-promises/
+	cp -a ./rudder-sources/rudder-techniques/initial-promises/node-server/ ./initial-promises
 
 ./fusioninventory-agent: /usr/bin/wget
 	#Original URL: http://search.cpan.org/CPAN/authors/id/F/FU/FUSINV/FusionInventory-Agent-$(FUSION_RELEASE).tar.gz


### PR DESCRIPTION
Stupid change of behavior between CentOS 3 and SLES 10...
