### PR TITLE
Fixes #3743 - Remove useless output of 'creating rudder database' in rudder-reports and redirect error output of a command line in rudder-upgrade

### DIFF
--- a/rudder-reports/debian/postinst
+++ b/rudder-reports/debian/postinst
@@ -45,7 +45,6 @@ case "$1" in
   echo " Done"
 
 
-  echo -n "INFO: Creating Rudder database..."
   dbname="rudder"
   usrname="rudder"
   CHK_PG_DB=$(su - postgres -c "psql -t -c \"select count(1) from pg_catalog.pg_database where datname = '${dbname}'\"")

--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -288,7 +288,7 @@ echo " Done"
 if [ ! -f /opt/rudder/etc/escaping_migration_done ]; then
 	echo -n "INFO: Converting escaped directive variabled to plain format..."
 	# If some entries match something like \" or \\, convert them to either " or \ and change them in the LDAP.
-	/opt/rudder/bin/ldapsearch -H ldap://localhost -x -D ${LDAP_USER} -w ${LDAP_PASSWORD} -b 'techniqueCategoryId=Active Techniques,ou=Rudder,cn=rudder-configuration' -LLL '(&(objectClass=directive)(|(directiveVariable=*\\"*)(directiveVariable=*\\\\*)))' directiveVariable \
+	/opt/rudder/bin/ldapsearch -H ldap://localhost -x -D ${LDAP_USER} -w ${LDAP_PASSWORD} -b 'techniqueCategoryId=Active Techniques,ou=Rudder,cn=rudder-configuration' -LLL '(&(objectClass=directive)(|(directiveVariable=*\\"*)(directiveVariable=*\\\\*)))' directiveVariable 2>/dev/null \
 	| perl -p0e "s/\n //g" \
 	|sed "s/\(ou=Rudder,cn=rudder-configuration\)/\1\nchangetype: modify\nreplace: directiveVariable/" \
 	|sed "s/\\\\\"/\"/g" \


### PR DESCRIPTION
Fixes #3743 - Remove useless output of 'creating rudder database' in rudder-reports and redirect error output of a command line in rudder-upgrade
