### PR TITLE
Fixes #3747 - Move on the begining of the script the initialization of variables which determine if CFEngine promises already exist

### DIFF
--- a/rudder-server-root/SOURCES/rudder-init.sh
+++ b/rudder-server-root/SOURCES/rudder-init.sh
@@ -39,6 +39,9 @@ REGEXP='s/^\([0-9]\{1,3\}\)\(.[0-9]\{1,3\}\)\(.[0-9]\{1,3\}\)\(.[0-9]\{1,3\}.[0-
 again="yes"
 cpt=0
 cpt2=0
+# Check if promises already exist for CFEngine community
+INITREP=/var/rudder/cfengine-community/inputs
+INITPRO=`ls ${INITREP} 2>/dev/null | wc -l`
 
 Pause()
 {
@@ -140,12 +143,6 @@ else
 	  fi
 	fi
 	#6th Step: Initial Promises
-	if [ -e /var/cfengine/inputs ];then
-		INITREP=/var/cfengine/inputs
-	else
-		INITREP=/var/rudder/cfengine-community/inputs
-	fi
-	INITPRO=`ls ${INITREP} | wc -l`
 	if [ ${INITPRO} -ne 0 ]
 	then
 	  while ! echo "$ANSWER6" | grep "^\(yes\|no\)$"


### PR DESCRIPTION
Fixes #3747 - Move on the begining of the script the initialization of variables which determine if CFEngine promises already exist
