### PR TITLE
Fixes #3864 - Fix wrong name of logrotate file in Debian/Ubuntu

### DIFF
--- a/rudder-server-root/debian/rules
+++ b/rudder-server-root/debian/rules
@@ -50,7 +50,7 @@ binary-arch: install
 #	dh_installdocs
 #	dh_installexamples
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-init.sh /opt/rudder/bin/
-	dh_installinit --noscripts --no-start --no-restart-on-upgrade --name=rudder-server-root
+	dh_installinit --noscripts --no-start --no-restart-on-upgrade --name=rudder
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-passwords.conf /opt/rudder/etc/
 #	dh_installmenu
 #	dh_installdebconf


### PR DESCRIPTION
Fixes #3864 - Fix wrong name of logrotate file in Debian/Ubuntu
