### PR TITLE
Fixes #3894 - unescape 'and' in cron file installed by packaging

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -119,6 +119,7 @@ localdepends: ./initial-promises ./files ./fusioninventory-agent ./tokyocabinet-
 	# Set unexpanded variables of the cron file
 	sed 's@\$${sys.workdir}@/var/rudder/cfengine-community@g' -i rudder-agent.cron
 	sed 's@\$${g.rudder_base}@/opt/rudder@g' -i rudder-agent.cron
+	sed  's@\\&\\&@\&\&@g' -i rudder-agent.cron
 
 ../debian/rudder-agent.cron: ./rudder-agent.cron
 	cp ./rudder-agent.cron ../debian/


### PR DESCRIPTION
Fixes #3894 - unescape 'and' in cron file installed by packaging
