### PR TITLE
Fixes #3900 - Change 'reload' of rsyslog into a 'restart' of rsyslog (as 'reload' does nothing on RHEL/CentOS)

### DIFF
--- a/rudder-inventory-endpoint/SPECS/rudder-inventory-endpoint.spec
+++ b/rudder-inventory-endpoint/SPECS/rudder-inventory-endpoint.spec
@@ -116,8 +116,8 @@ cp %{SOURCE1} %{buildroot}/opt/rudder/etc/
 # Post Installation
 #=================================================
 
-echo "Reloading syslogd ..."
-%{sysloginitscript} reload
+echo "Restarting syslogd ..."
+%{sysloginitscript} restart
 
 #=================================================
 # Cleaning

--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -186,8 +186,8 @@ cp %{SOURCE5} %{buildroot}%{rudderdir}/bin/
 echo "Setting Apache HTTPd as a boot service"
 /sbin/chkconfig --add %{apache}
 
-echo "Reloading syslog"
-%{sysloginitscript} reload
+echo "Restarting syslog"
+%{sysloginitscript} restart
 
 /etc/init.d/%{apache} stop
 # a2dissite default


### PR DESCRIPTION
Fixes #3900 - Change 'reload' of rsyslog into a 'restart' of rsyslog (as 'reload' does nothing on RHEL/CentOS)

See http://www.rudder-project.org/redmine/issues/3900
