### PR TITLE
bugfix: cannot remove rudder-agent if cf-* are not running

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -290,7 +290,9 @@ echo "INFO: A back up copy of the /var/rudder/cfengine-community/ppkeys has been
 if [ $1 -eq 0 ]; then
   # Make sure that CFEngine is not running anymore
   for component in cf-agent cf-serverd cf-execd cf-monitord; do
-    kill -9 `pidof ${component}`
+    if pid=`pidof ${component}`; then
+      kill -9 ${pid}
+    fi
   done
 
   # Remove the cron script we create at installation to prevent mail

--- a/rudder-agent/debian/postrm
+++ b/rudder-agent/debian/postrm
@@ -23,7 +23,9 @@ case "$1" in
 	purge|remove)
 		# Make sure that CFEngine is not running anymore
 		for component in cf-agent cf-serverd cf-execd cf-monitord; do
-			kill -9 `pidof ${component}`
+			if pid=`pidof ${component}`; then
+				kill -9 ${pid}
+			fi
 		done
 
 		# Remove the cron script we create at installation to prevent mail


### PR DESCRIPTION
Because of "set -e", we need to test if cf-\* processes are running before killing them, otherwise
postrm fails and we cannot uninstall the package.
