### PR TITLE
Fixes #3925: Prevent UUID removal when upgrading rudder-agent

### DIFF
--- a/rudder-agent/SOURCES/check-rudder-agent
+++ b/rudder-agent/SOURCES/check-rudder-agent
@@ -1,0 +1,81 @@
+#!/bin/sh
+#####################################################################################
+# Copyright 2013 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+set -e
+
+check_and_fix_cfengine_processes() {
+
+# Default variables for CFEngine binaries and disable files
+CFE_DIR=/var/rudder/cfengine-community
+CFE_BIN_DIR=${CFE_BIN_DIR}/bin
+CFE_DISABLE_FILE=/opt/rudder/etc/disable-agent
+
+# If no disable file AND no process of CFEngine from Rudder, then relaunch cf-agent with a failsafe first
+# But this is applied only on servers or nodes already initialized (policy server set)
+if [ ! -e ${CFE_DISABLE_FILE} -a `ps -efww | grep -E "(cf-execd|cf-agent)" | grep -E "${CFE_BIN_DIR}/(cf-execd|cf-agent)" | grep -v grep | wc -l` -eq 0 -a -f ${CFE_DIR}/policy_server.dat ]; then
+  echo -n "WARNING: No disable file detected and no CFEngine process neither. Relaunching CFEngine processes..."
+  ${CFE_BIN_DIR}/cf-agent -f failsafe.cf >/dev/null 2>&1
+  ${CFE_BIN_DIR}/cf-agent >/dev/null 2>&1
+  echo " Done"
+fi
+}
+
+check_and_fix_rudder_uuid() {
+
+# Default variables about UUID file and its backups
+BACKUP_DIR=/var/backups/rudder/
+UUID_FILE=/opt/rudder/etc/uuid.hive
+LATEST_BACKUPED_UUID=""
+
+# Generate a UUID if we don't have one yet
+if [ ! -e ${UUID_FILE} ]; then
+  if [ -d ${BACKUP_DIR} ]; then
+    LATEST_BACKUPED_UUID=$(ls -v1 ${BACKUP_DIR} | tail -n1)
+  fi
+  if [ -f ${BACKUP_DIR}${LATEST_BACKUPED_UUID} ]; then
+    echo -n "WARNING: The UUID of the node does not exist. The lastest backup (${LATEST_BACKUPED_UUID}) will be recovered..."
+    cp -a ${BACKUP_DIR}${LATEST_BACKUPED_UUID} ${UUID_FILE} >/dev/null 2>&1
+    echo " Done"
+  else
+    echo -n "WARNING: The UUID of the node does not exist and no backup exist. A new one will be generated..."
+    uuidgen > ${UUID_FILE}
+    echo " Done"
+  fi
+else
+  # UUID is valid only if it has been generetaed by uuidgen or if it is set to 'root' for policy server
+  CHECK_UUID=`cat /opt/rudder/etc/uuid.hive | grep -E "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}|root" | wc -l`
+  # If the UUID is not valid, regenerate it
+  if [ ${CHECK_UUID} -ne 1 ]; then
+    echo -n "INFO: Creating a new UUID for Rudder as the existing one is invalid..."
+    # Keep a backup of UUID even if it is not valid
+    mkdir -p /var/backups/rudder
+    cp -f /opt/rudder/etc/uuid.hive /var/backups/rudder/uuid-$(date +%Y%m%d).hive
+    # Generate a new one
+    uuidgen > ${UUID_FILE}
+    echo " Done."
+  fi
+fi
+}
+
+# Ensure script is executed by root
+if [ ! $(whoami) = 'root' ];then echo "You must be root"; exit; fi
+
+# Launch each check with a certain order
+check_and_fix_rudder_uuid
+check_and_fix_cfengine_processes

--- a/rudder-agent/debian/postinst
+++ b/rudder-agent/debian/postinst
@@ -20,6 +20,7 @@ set -e
 
 case "$1" in
 	configure)
+
 		# Is this the first installation?
 		CFRUDDER_FIRST_INSTALL=0
 		if [ ! -x /var/rudder/cfengine-community/bin/cf-execd ]; then CFRUDDER_FIRST_INSTALL=1; fi
@@ -76,23 +77,23 @@ case "$1" in
 			echo " Done."
 		fi
 
-		# Generate a UUID if we don't have one yet
-		if [ ! -e /opt/rudder/etc/uuid.hive ]
-		then
-			echo -n "INFO: Creating a new UUID for Rudder..."
-			uuidgen > /opt/rudder/etc/uuid.hive
-			echo " Done."
-		else
-			# UUID is valid only if it has been generetaed by uuidgen or if it is set to 'root' for policy server
-			CHECK_UUID=`cat /opt/rudder/etc/uuid.hive | grep -E "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}|root" | wc -l`
-			# If the UUID is not valid, regenerate it
-			if [ ${CHECK_UUID} -ne 1 ]
-			then
-				echo -n "INFO: Creating a new UUID for Rudder as the existing one is invalid..."
-				uuidgen > /opt/rudder/etc/uuid.hive
-				echo " Done."
+		# Add temporary cron for checking UUID. This cron is created in postinst
+		# in order to remove it later without complains of the package manager.
+		CHECK_RUDDER_AGENT_CRON=`grep "/opt/rudder/bin/check-rudder-agent" /etc/cron.d/rudder-agent | wc -l`
+		TMP_CRON=/etc/cron.d/rudder-agent-uuid
+		# Add it only if the default cron file does not call check-rudder-agent script
+		if [ ${CHECK_RUDDER_AGENT_CRON} -eq 0 ]; then
+			if [ ! -f ${TMP_CRON} ]; then
+				echo "0,5,10,15,20,25,30,35,40,45,50,55 * * * * root /opt/rudder/bin/check-rudder-agent" > ${TMP_CRON}
 			fi
 		fi
+
+		# Vixie-cron and cronie (at least) expect specific permissions to be applied
+		# on /etc/cron.d entries, and will refuse to load executable files.
+		if [ -f ${TMP_CRON} ]; then
+			chmod 644 ${TMP_CRON}
+		fi
+
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -77,6 +77,8 @@ binary-arch: install
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES initial-promises /opt/rudder/share
 	# Install an empty uuid.hive file before generating an uuid
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ uuid.hive /opt/rudder/etc/
+	# Install a verification script for cron
+	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ check-rudder-agent /opt/rudder/bin/
 #	dh_installcron
 #	dh_installinfo
 	dh_installman

--- a/rudder-server-root/SPECS/rudder-server-root.spec
+++ b/rudder-server-root/SPECS/rudder-server-root.spec
@@ -104,8 +104,11 @@ cp %{SOURCE6} %{buildroot}%{rudderdir}/etc/
 #=================================================
 # Post Installation
 #=================================================
-# Is this the first installation?
+# This package is only installed by the root server
+# then we can set UUID to 'root' serenly
 echo 'root' > %{rudderdir}/etc/uuid.hive
+
+# Check if Rudder LDAP has already been initialize previously
 LDAPCHK=`/opt/rudder/sbin/slapcat  | grep "^dn: " | wc -l`
 if [ $LDAPCHK -eq 0 ]; then
   echo "************************************************************"

--- a/rudder-server-root/debian/postinst
+++ b/rudder-server-root/debian/postinst
@@ -20,8 +20,11 @@ set -e
 
 case "$1" in
     configure)
+		# This package is only installed by the root server
+		# then we can set UUID to 'root' serenly
 		echo 'root' > /opt/rudder/etc/uuid.hive
-		# Is this the first installation?
+
+		# Check if Rudder LDAP has already been initialize previously
 		LDAPCHK=`/opt/rudder/sbin/slapcat  | grep "^dn: " | wc -l`
 		if [ $LDAPCHK -eq 0 ]; then
 			echo "************************************************************"


### PR DESCRIPTION
- Add script to check UUID of Rudder and CFEngine process, and set 'root' to UUID only during rudder-server-root install but use the script during upgrade
- Add GPLv3 License to new script
- Fix typos and change name check_rudder-ganet to check-rudder-agent
- Remove changes and add comments on rudder-server-root package, Add temporary cron set into rudder-agent postinst and comments for check-rudder-agent
- Add comments in rudder-agent postinst
- Fix wrong files and bizarre logics
- Make sure that the cron fule added in this issue has correct permissions

Ticket: http://www.rudder-project.org/redmine/issues/3925

To be merged in 2.4 branch.
