### PR TITLE
Fixes #3981 - Change logrotate on Debian/Ubuntu to be /etc/logrotate.d/rudder

### DIFF
--- a/rudder-server-root/SOURCES/Makefile
+++ b/rudder-server-root/SOURCES/Makefile
@@ -20,7 +20,7 @@
 
 RUDDER_VERSION_TO_PACKAGE = <put Rudder version or version-snapshot here>
 
-localdepends: ./rudder-sources ../debian/rudder-server-root.logrotate ../debian/rudder-server-root.init ./rudder.logrotate.suse
+localdepends: ./rudder-sources ../debian/rudder.logrotate ../debian/rudder-server-root.init ./rudder.logrotate.suse
 
 ./rudder-sources.tar.bz2:
 	$(WGET) -O rudder-sources.tar.bz2 http://www.rudder-project.org/archives/rudder-sources-${RUDDER_VERSION_TO_PACKAGE}.tar.bz2
@@ -37,8 +37,8 @@ localdepends: ./rudder-sources ../debian/rudder-server-root.logrotate ../debian/
 ./rudder.logrotate.suse: ./rudder-sources
 	cp -a ./rudder-sources/rudder-techniques/techniques/system/distributePolicy/1.0/logrotate.suse.st ./rudder.logrotate.suse
 
-../debian/rudder-server-root.logrotate: ./rudder.logrotate.debian
-	cp rudder.logrotate.debian ../debian/rudder-server-root.logrotate
+../debian/rudder.logrotate: ./rudder.logrotate.debian
+	cp rudder.logrotate.debian ../debian/rudder.logrotate
 
 ../debian/rudder-server-root.init:
 	cp rudder-server-root.init ../debian/

--- a/rudder-server-root/debian/conffiles
+++ b/rudder-server-root/debian/conffiles
@@ -1,2 +1,2 @@
 /opt/rudder/etc/rudder-passwords.conf
-/etc/logrotate.d/rudder-server-root
+/etc/logrotate.d/rudder

--- a/rudder-server-root/debian/rules
+++ b/rudder-server-root/debian/rules
@@ -54,7 +54,7 @@ binary-arch: install
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-passwords.conf /opt/rudder/etc/
 #	dh_installmenu
 #	dh_installdebconf
-	dh_installlogrotate
+	dh_installlogrotate --name=rudder
 #	dh_installmime
 #	dh_python
 #	dh_installcron


### PR DESCRIPTION
Fixes #3981 - Change logrotate on Debian/Ubuntu to be /etc/logrotate.d/rudder

See http://www.rudder-project.org/redmine/issues/3981
