### PR TITLE
Fixes #3997 - Add backup of /etc/{init.d,default}/rudder-agent in preinst and restore action in check-rudder-agent cron file

### DIFF
--- a/rudder-agent/SOURCES/check-rudder-agent
+++ b/rudder-agent/SOURCES/check-rudder-agent
@@ -19,6 +19,8 @@
 
 set -e
 
+BACKUP_DIR=/var/backups/rudder/
+
 check_and_fix_cfengine_processes() {
 
 # Default variables for CFEngine binaries and disable files
@@ -39,14 +41,13 @@ fi
 check_and_fix_rudder_uuid() {
 
 # Default variables about UUID file and its backups
-BACKUP_DIR=/var/backups/rudder/
 UUID_FILE=/opt/rudder/etc/uuid.hive
 LATEST_BACKUPED_UUID=""
 
 # Generate a UUID if we don't have one yet
 if [ ! -e ${UUID_FILE} ]; then
   if [ -d ${BACKUP_DIR} ]; then
-    LATEST_BACKUPED_UUID=$(ls -v1 ${BACKUP_DIR} | tail -n1)
+    LATEST_BACKUPED_UUID=$(ls -v1 ${BACKUP_DIR}uuid-*.hive | tail -n1)
   fi
   if [ -f ${BACKUP_DIR}${LATEST_BACKUPED_UUID} ]; then
     echo -n "WARNING: The UUID of the node does not exist. The lastest backup (${LATEST_BACKUPED_UUID}) will be recovered..."
@@ -73,9 +74,33 @@ else
 fi
 }
 
+
+check_and_fix_specific_rudder_agent_file() {
+
+FILE_TO_RESTORE=$1
+FILE_TYPE=$2
+LATEST_BACKUPED_FILES=""
+
+if [ ! -e ${FILE_TO_RESTORE} ]; then
+  if [ -d ${BACKUP_DIR} ]; then
+    LATEST_BACKUPED_FILES=$(ls -v1 ${BACKUP_DIR}rudder-agent.${FILE_TYPE}-* | tail -n1)
+  fi
+  if [ -f ${LATEST_BACKUPED_FILES} ]; then
+    echo -n "WARNING: The file ${FILE_TO_RESTORE} does not exist. The lastest backup (${LATEST_BACKUPED_FILES}) will be recovered..."
+    cp -a ${LATEST_BACKUPED_FILES} ${FILE_TO_RESTORE} >/dev/null 2>&1
+    echo " Done"
+  else
+    echo "WARNING: The file ${FILE_TO_RESTORE} does not exist and no backup exist. Please reinstall the rudder-agent package"
+  fi
+fi
+}
+
+
 # Ensure script is executed by root
 if [ ! $(whoami) = 'root' ];then echo "You must be root"; exit; fi
 
 # Launch each check with a certain order
 check_and_fix_rudder_uuid
 check_and_fix_cfengine_processes
+check_and_fix_specific_rudder_agent_file /etc/init.d/rudder-agent init
+check_and_fix_specific_rudder_agent_file /etc/default/rudder-agent default

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -171,6 +171,12 @@ install -m 755 %{SOURCE5} %{buildroot}/opt/rudder/bin/check-rudder-agent
 # Pre Installation
 #=================================================
 
+# Keep a backup copy of Rudder agent init and cron files to prevent http://www.rudder-project.org/redmine/issues/3995
+cp -af /etc/init.d/rudder-agent /var/backups/rudder/rudder-agent.init-$(date +%Y%m%d)
+echo "INFO: A back up copy of the /etc/init.d/rudder-agent has been created in /var/backups/rudder"
+cp -af /etc/default/rudder-agent /var/backups/rudder/rudder-agent.default-$(date +%Y%m%d)
+echo "INFO: A back up copy of the /etc/default/rudder-agent has been created in /var/backups/rudder"
+
 %post -n rudder-agent
 #=================================================
 # Post Installation


### PR DESCRIPTION
Fixes #3997 - Add backup of /etc/{init.d,default}/rudder-agent in preinst and restore action in check-rudder-agent cron file

See http://www.rudder-project.org/redmine/issues/3997
