### PR TITLE
Fixes #3998 - Create backup directory in rudder-agent preinst before any action on it

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -172,6 +172,7 @@ install -m 755 %{SOURCE5} %{buildroot}/opt/rudder/bin/check-rudder-agent
 #=================================================
 
 # Keep a backup copy of Rudder agent init and cron files to prevent http://www.rudder-project.org/redmine/issues/3995
+mkdir -p /var/backups/rudder
 cp -af /etc/init.d/rudder-agent /var/backups/rudder/rudder-agent.init-$(date +%Y%m%d)
 echo "INFO: A back up copy of the /etc/init.d/rudder-agent has been created in /var/backups/rudder"
 cp -af /etc/default/rudder-agent /var/backups/rudder/rudder-agent.default-$(date +%Y%m%d)


### PR DESCRIPTION
Fixes #3998 - Create backup directory in rudder-agent preinst before any action on it

See http://www.rudder-project.org/redmine/issues/3998
