### PR TITLE
Fixes #4000 - Prevent backup of inexistent files for rudder-agent (if it's the first install)

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -171,12 +171,15 @@ install -m 755 %{SOURCE5} %{buildroot}/opt/rudder/bin/check-rudder-agent
 # Pre Installation
 #=================================================
 
-# Keep a backup copy of Rudder agent init and cron files to prevent http://www.rudder-project.org/redmine/issues/3995
-mkdir -p /var/backups/rudder
-cp -af /etc/init.d/rudder-agent /var/backups/rudder/rudder-agent.init-$(date +%Y%m%d)
-echo "INFO: A back up copy of the /etc/init.d/rudder-agent has been created in /var/backups/rudder"
-cp -af /etc/default/rudder-agent /var/backups/rudder/rudder-agent.default-$(date +%Y%m%d)
-echo "INFO: A back up copy of the /etc/default/rudder-agent has been created in /var/backups/rudder"
+# Do this only during upgrade process
+if [ $1 -eq 2 ];then
+	# Keep a backup copy of Rudder agent init and cron files to prevent http://www.rudder-project.org/redmine/issues/3995
+	mkdir -p /var/backups/rudder
+	cp -af /etc/init.d/rudder-agent /var/backups/rudder/rudder-agent.init-$(date +%Y%m%d)
+	echo "INFO: A back up copy of the /etc/init.d/rudder-agent has been created in /var/backups/rudder"
+	cp -af /etc/default/rudder-agent /var/backups/rudder/rudder-agent.default-$(date +%Y%m%d)
+	echo "INFO: A back up copy of the /etc/default/rudder-agent has been created in /var/backups/rudder"
+fi
 
 %post -n rudder-agent
 #=================================================


### PR DESCRIPTION
Fixes #4000 - Prevent backup of inexistent files for rudder-agent (if it's the first install)

See http://www.rudder-project.org/redmine/issues/4000
