### PR TITLE
Fixes #4001 - Change output redirections command of rudder-init.sh in order to be SLES compliant

### DIFF
--- a/rudder-server-root/SOURCES/rudder-init.sh
+++ b/rudder-server-root/SOURCES/rudder-init.sh
@@ -247,9 +247,9 @@ echo -n "Restarting services..."
 /opt/rudder/bin/cf-agent &> $TMP_LOG
 
 # Start the whole infrastructure
-/etc/init.d/rudder-agent restart &>> $TMP_LOG
-if [ -e $LDAPDATA_PATH ]; then /etc/init.d/slapd start &>> $TMP_LOG; fi
-/etc/init.d/jetty restart &>> $TMP_LOG || echo "WARNING: Jetty failed to start, maybe there is not enough RAM or swap on the machine. Skipping..."
+/etc/init.d/rudder-agent restart >> ${TMP_LOG} 2>&1
+if [ -e ${LDAPDATA_PATH} ]; then /etc/init.d/slapd start >> ${TMP_LOG} 2>&1; fi
+/etc/init.d/jetty restart >> ${TMP_LOG} 2>&1 || echo "WARNING: Jetty failed to start, maybe there is not enough RAM or swap on the machine. Skipping..."
 echo " done."
 
 echo


### PR DESCRIPTION
Fixes #4001 - Change output redirections command of rudder-init.sh in order to be SLES compliant

See http://www.rudder-project.org/redmine/issues/4001
