### PR TITLE
Fixes #4067: Fix a naming issue in rudder-webapp debian package (vhost.c...

### DIFF
--- a/rudder-webapp/debian/rules
+++ b/rudder-webapp/debian/rules
@@ -76,8 +76,10 @@ binary-arch: install
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-core/src/main/resources/ reportsInfo.xml /opt/rudder/etc/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/ load-page/  /opt/rudder/share/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/ rudder-apache-common.conf /opt/rudder/etc/
-	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/ rudder-vhost /etc/apache2/sites-available/
-	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/ rudder-vhost-ssl /etc/apache2/sites-available/
+	cp $(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/rudder-vhost.conf $(CURDIR)/BUILD/rudder-vhost
+	cp $(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/rudder-vhost-ssl.conf $(CURDIR)/BUILD/rudder-vhost-ssl
+	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-vhost /etc/apache2/sites-available/
+	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-vhost-ssl /etc/apache2/sites-available/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder.xml /opt/rudder/jetty7/contexts/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-networks.conf /opt/rudder/etc/
 


### PR DESCRIPTION
...onf not renamed)

Ticket: bug_4067/dev/4067_correct_rudder_vhost_copy

To be merged in master
