### PR TITLE
fixes #4109: correct rudder agent cron name to be compliant with

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -27,7 +27,7 @@ WGET := $(if $(PROXY), http_proxy=$(PROXY) ftp_proxy=$(PROXY)) /usr/bin/wget
 PATCH := /usr/bin/patch
 FIND := /usr/bin/find
 
-localdepends: ./initial-promises ./files ./fusioninventory-agent ./tokyocabinet-source ./cfengine-source ../debian/rudder-agent.init ../debian/rudder-agent.default ./rudder-agent.cron ../debian/rudder-agent.cron
+localdepends: ./initial-promises ./files ./fusioninventory-agent ./tokyocabinet-source ./cfengine-source ../debian/rudder-agent.init ../debian/rudder-agent.default ./rudder-agent.cron ../debian/rudder-agent.cron.d
 	rm -rf $(TMP_DIR)
 
 ./cfengine-source: /usr/bin/wget
@@ -123,8 +123,8 @@ localdepends: ./initial-promises ./files ./fusioninventory-agent ./tokyocabinet-
 	sed  's@\\&\\&@\&\&@g' -i rudder-agent.cron
 	sed  's@\\&1@\&1@g' -i rudder-agent.cron
 
-../debian/rudder-agent.cron: ./rudder-agent.cron
-	cp ./rudder-agent.cron ../debian/
+../debian/rudder-agent.cron.d: ./rudder-agent.cron
+	cp ./rudder-agent.cron ../debian/rudder-agent.cron.d
 
 /usr/bin/wget:
 	sudo apt-get --assume-yes install wget
@@ -142,7 +142,7 @@ localclean:
 	rm -rf ./perl-custom
 	rm -rf ./files
 	rm -rf ./rudder-sources
-	rm -f ./rudder-agent.cron ../debian/rudder-agent.cron
+	rm -f ./rudder-agent.cron ../debian/rudder-agent.cron.d
 
 veryclean:
 	rm -f ./rudder-sources.tar.bz2


### PR DESCRIPTION
dh_installcron

http://www.rudder-project.org/redmine/issues/4109
