### PR TITLE
Fixes #4147: Enforce creation of UUID at first install

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -286,6 +286,9 @@ if [ -f ${TMP_CRON} ]; then
 	chmod 644 ${TMP_CRON}
 fi
 
+# launch rudder agent check script, it will generate an UUID on first install or repair it if needed
+/opt/rudder/bin/check-rudder-agent
+
 %preun -n rudder-agent
 #=================================================
 # Pre Uninstallation

--- a/rudder-agent/debian/postinst
+++ b/rudder-agent/debian/postinst
@@ -105,6 +105,9 @@ case "$1" in
 			chmod 644 ${TMP_CRON}
 		fi
 
+		# launch rudder agent check script, it will generate an UUID on first install or repair it if needed
+		/opt/rudder/bin/check-rudder-agent
+
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
See 2nd answer here : http://askubuntu.com/questions/101962/script-to-only-execute-during-first-install-of-a-package

Is there a reason why we define CFRUDDER_FIRST_INSTALL if there is a way for each packaging system to determine if it's an upgrade or a first install 

for RPM look at this link (section Deal with upgrade) http://wiki.mandriva.com/en/Development/Howto/RPM

http://www.rudder-project.org/redmine/issues/4147
