### PR TITLE
Fixes #4229: Init NCF during first install instead of copying it

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -220,7 +220,7 @@ then
 		mkdir -p /var/rudder/configuration-repository/shared-files
 		touch /var/rudder/configuration-repository/shared-files/.placeholder
 		cp -a %{rudderdir}/share/techniques /var/rudder/configuration-repository/
-		cp -a %{sharedir}/ncf /var/rudder/configuration-repository/
+		ncf init /var/rudder/configuration-repository/ncf
 fi
 
 # Update /etc/sysconfig/apache2 in case an old module loading entry has already been created by Rudder
@@ -296,7 +296,7 @@ if [ ! -d /var/rudder/configuration-repository/techniques ]; then
 	cp -a %{rudderdir}/share/techniques /var/rudder/configuration-repository/
 fi
 if [ ! -d /var/rudder/configuration-repository/ncf ]; then
-	cp -a %{sharedir}/ncf /var/rudder/configuration-repository/
+	ncf init /var/rudder/configuration-repository/ncf
 fi
 
 # Warn the user that Jetty needs restarting. This can't be done automatically due to a bug in Jetty's init script.

--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -88,7 +88,7 @@ case "$1" in
 		cp -a /opt/rudder/share/techniques /var/rudder/configuration-repository/
 	fi
 	if [ ! -d /var/rudder/configuration-repository/ncf ]; then
-		cp -a /usr/share/ncf /var/rudder/configuration-repository/
+		ncf init /var/rudder/configuration-repository/ncf
 	fi
 
 	# Only for Ubuntu:


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/4229

To be merged in 2.9
