### PR TITLE
Fixes #4284: Fix the ncf symlink which was still broken after #4220

### DIFF
--- a/ncf/SPECS/ncf.spec
+++ b/ncf/SPECS/ncf.spec
@@ -80,7 +80,10 @@ mkdir -p %{buildroot}%{installdir}/
 mkdir -p %{buildroot}%{bindir}/
 
 cp -r %{SOURCE1}/ncf/ %{buildroot}%{installdir}/
-ln -sf %{bindir}/ncf %{buildroot}%{bindir}/ncf
+
+# Create a symlink to make ncf available as part of the
+# default PATH
+ln -sf %{installdir}/ncf/ncf %{buildroot}%{bindir}/ncf
 
 %pre -n ncf
 #=================================================


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/4284

To be merged in 2.9
