### PR TITLE
Fixes #4314: Add a fix in Fusion Inventory to prevent CFEngine report tr...

### DIFF
--- a/rudder-agent/SOURCES/4096_char_line_truncating.patch
+++ b/rudder-agent/SOURCES/4096_char_line_truncating.patch
@@ -1,0 +1,17 @@
+--- a/lib/FusionInventory/Agent/Tools/Unix.pm	2012-05-29 11:20:24.000000000 +0200
++++ b/lib/FusionInventory/Agent/Tools/Unix.pm	2014-01-03 15:27:00.000000000 +0100
+@@ -288,6 +288,13 @@
+         my $time = $10;
+         my $cmd = $11;
+ 
++        # Rudder #4314/Alex Tkatchenko: Workaround for a CFEngine bug that truncates
++        # lines exceeding 4096 chars.
++        #
++        # See https://cfengine.com/dev/issues/3882 for defails.
++
++        $cmd = substr $cmd,0,4076 if length($cmd) > 4076;
++
+ 	# try to get a consistant time format
+         my $begin;
+         if ($started =~ /^(\d{1,2}):(\d{2})/) {
+

--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -65,6 +65,7 @@ localdepends: ./initial-promises ./files ./fusioninventory-agent ./tokyocabinet-
 	$(PATCH) -d ./fusioninventory-agent -p1 < ./SuSE_service_pack.patch
 	$(PATCH) -d ./fusioninventory-agent -p1 < ./Scientific_linux_distro_name.patch
 	$(PATCH) -d ./fusioninventory-agent -p1 < ./Oracle_linux_distro_name.patch
+	$(PATCH) -d ./fusioninventory-agent -p1 < ./4096_char_line_truncating.patch
 	# Fix a lsusb invocation that crashes some SLES machines
 	$(FIND) ./fusioninventory-agent -iname "USB.pm" -exec rm "{}" \;
 


### PR DESCRIPTION
...uncation from breaking reports with very long process commands

Ticket: http://www.rudder-project.org/redmine/issues/4314

To be merged in 2.6
