### PR TITLE
Refs #3928: add a check in script to count number of agent/executor running, and kill them if more than 8 are running

### DIFF
--- a/rudder-agent/SOURCES/check-rudder-agent
+++ b/rudder-agent/SOURCES/check-rudder-agent
@@ -62,7 +62,7 @@ fi
 # If there are more than 8 agent/executor processes, we should kill them, and purge the tcdb database
 if [ ${NB_CF_PROCESS_RUNNING} -gt 8 ]; then
   echo -n "WARNING: Too many instance of CFEngine processes running. Killing them, and purging the TokyoCabinet database..."
-  echo "${CF_PROCESS_RUNNING}" | awk 'BEGIN { OFS=" "} {print $2 }' | xargs kill -9
+  echo "${CF_PROCESS_RUNNING}" | awk 'BEGIN { OFS=" "} {print $2 }' | xargs kill -9 || true
   /etc/init.d/rudder-agent forcestop || true
   rm -f ${CFE_DIR}/state/cf_lock.tdcb
   rm -f ${CFE_DIR}/state/cf_lock.tdcb.lock

--- a/rudder-agent/SOURCES/vzps.py
+++ b/rudder-agent/SOURCES/vzps.py
@@ -51,11 +51,10 @@ def main():
                 print('Invalid CTID')
                 sys.exit(1)
             CTID = sys.argv[2]
+            if len(sys.argv) >= 4:
+                ps_args = sys.argv[3:]
         else:
             ps_args = sys.argv[1:]
-
-    if len(sys.argv) >= 4:
-        ps_args = sys.argv[3:]
 
     # Join ps_args if it's a list
     if isinstance(ps_args, list):

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -248,6 +248,8 @@ install -m 644 %{SOURCE6} %{buildroot}/etc/ld.so.conf.d/rudder.conf
 
 install -m 755 %{SOURCE7} %{buildroot}/opt/rudder/bin/check-rudder-agent
 
+install -m 755 %{SOURCE7} %{buildroot}/opt/rudder/bin/vzps.py
+
 %pre -n rudder-agent
 #=================================================
 # Pre Installation

--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -79,6 +79,8 @@ binary-arch: install
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ uuid.hive /opt/rudder/etc/
 	# Install a verification script for cron
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ check-rudder-agent /opt/rudder/bin/
+	# Install script to get local processes on VZ systems
+	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ vzps.py /opt/rudder/bin/
 	dh_installcron
 #	dh_installinfo
 	dh_installman


### PR DESCRIPTION
The check is at 8, since in the common Technique the kill happens at 8 instance of agent
