### PR TITLE
Fixes #4421: Fix a missing file in rudder-server-root RPM packaging

### DIFF
--- a/rudder-server-root/SPECS/rudder-server-root.spec
+++ b/rudder-server-root/SPECS/rudder-server-root.spec
@@ -102,6 +102,7 @@ cp %{SOURCE3} %{buildroot}%{rudderdir}/bin/
 cp %{SOURCE4} %{buildroot}/etc/logrotate.d/rudder
 cp %{SOURCE5} %{buildroot}/etc/init.d/rudder-server-root
 cp %{SOURCE6} %{buildroot}%{rudderdir}/etc/
+cp %{SOURCE7} %{buildroot}%{rudderdir}/bin/
 
 
 %pre -n rudder-server-root

--- a/rudder-server-root/debian/dirs
+++ b/rudder-server-root/debian/dirs
@@ -1,6 +1,5 @@
 opt/rudder/bin
 opt/rudder/share/initial-promises/
-opt/rudder/share/initial-promises/
 var/rudder/cfengine-community/inputs/
 var/cfengine/
 var/cfengine/inputs/


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/4421

To be merged in 2.9
