### PR TITLE
Fixes #4569: rsyslogd: could not load module '/usr/lib/rsyslog/ompgsql.s...

### DIFF
--- a/rudder-reports/debian/control
+++ b/rudder-reports/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.rudder-project.org
 
 Package: rudder-reports
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql (>=8)
+Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql (>=8), rsyslog, rsyslog-pgsql
 Description: Configuration management and audit tool - reports database
  Rudder is an open source configuration management and audit solution.
  .


### PR DESCRIPTION
...o', dlopen: /usr/lib/rsyslog/ompgsql.so: cannot open shared object file: No such file or directory

See http://www.rudder-project.org/redmine/issues/4569#change-25236
