### PR TITLE
Fixes #4738: Prevent a stray warning from occurring while starting jetty...

### DIFF
--- a/rudder-jetty/SOURCES/jetty-init-rudder.patch
+++ b/rudder-jetty/SOURCES/jetty-init-rudder.patch
@@ -1,6 +1,6 @@
 --- jetty7/bin/jetty.sh 2011-09-12 11:07:16.913497607 +0200
 +++ jetty7/bin/jetty.sh 2011-09-12 12:15:32.633499423 +0200
-@@ -394,6 +394,29 @@
+@@ -426,6 +426,32 @@
    echo "RUN_CMD        =  ${RUN_CMD}"
  fi
  
@@ -8,23 +8,26 @@
 +# Check rudder plugins before action
 +#####################################################
 +PLUGINSDIR='/opt/rudder/jetty7/rudder-plugins/'
-+CHKPLUGIN=`ls $PLUGINSDIR | wc -l`
-+PLUGINSPATH=""
 +
-+CPT=0
-+if [ $CHKPLUGIN -gt 0 ]
-+then
-+    for fic in $PLUGINSDIR*
-+    do
-+        if [ $CPT -eq 0 ]
-+        then
-+            PLUGINSPATH=$fic
-+        else
-+            PLUGINSPATH="$PLUGINSPATH,$fic"
-+        fi
-+        CPT=$(($CPT+1))
-+    done
-+sed -i "s%extraClasspath\">.*</S%extraClasspath\">$PLUGINSPATH</S%" /opt/rudder/jetty7/contexts/rudder.xml
++if [ -d "$PLUGINSDIR" ]; then
++    CHKPLUGIN=`ls $PLUGINSDIR | wc -l`
++    PLUGINSPATH=""
++
++    CPT=0
++    if [ $CHKPLUGIN -gt 0 ]
++    then
++        for fic in $PLUGINSDIR*
++        do
++            if [ $CPT -eq 0 ]
++            then
++                PLUGINSPATH=$fic
++            else
++                PLUGINSPATH="$PLUGINSPATH,$fic"
++            fi
++            CPT=$(($CPT+1))
++        done
++    sed -i "s%extraClasspath\">.*</S%extraClasspath\">$PLUGINSPATH</S%" /opt/rudder/jetty7/contexts/rudder.xml
++    fi
 +fi
 +
  ##################################################


### PR DESCRIPTION
... if the Rudder plugins directory is missing

Ticket: http://www.rudder-project.org/redmine/issues/4738

To be merged in 2.10
