### PR TITLE
Fixes #4801: Do not backup/restore sysv init scripts on AIX on rudder-ag...

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -315,14 +315,15 @@ find %{buildroot}%{rudderdir} %{buildroot}%{ruddervardir} -type f -o -type l | s
 
 # Do this only during upgrade process
 if [ $1 -eq 2 ];then
+%if "%{?_os}" != "aix"
 	# Keep a backup copy of Rudder agent init and cron files to prevent http://www.rudder-project.org/redmine/issues/3995
 	mkdir -p /var/backups/rudder
-	%{install_command} -m 755 /etc/init.d/rudder-agent /var/backups/rudder/rudder-agent.init-$(date +%Y%m%d)
-	echo "INFO: A back up copy of the /etc/init.d/rudder-agent has been created in /var/backups/rudder"
-	%{install_command} -m 644 /etc/default/rudder-agent /var/backups/rudder/rudder-agent.default-$(date +%Y%m%d)
-	echo "INFO: A back up copy of the /etc/default/rudder-agent has been created in /var/backups/rudder"
-	%{install_command} -m 644 /etc/cron.d/rudder-agent /var/backups/rudder/rudder-agent.cron-$(date +%Y%m%d)
-	echo "INFO: A back up copy of the /etc/cron.d/rudder-agent has been created in /var/backups/rudder"
+	%{install_command} -m 755 /etc/init.d/rudder-agent /var/backups/rudder/rudder-agent.init-$(date +%Y%m%d) && echo "INFO: A back up copy of the /etc/init.d/rudder-agent has been created in /var/backups/rudder"
+	%{install_command} -m 644 /etc/default/rudder-agent /var/backups/rudder/rudder-agent.default-$(date +%Y%m%d) && echo "INFO: A back up copy of the /etc/default/rudder-agent has been created in /var/backups/rudder"
+	%{install_command} -m 644 /etc/cron.d/rudder-agent /var/backups/rudder/rudder-agent.cron-$(date +%Y%m%d) && echo "INFO: A back up copy of the /etc/cron.d/rudder-agent has been created in /var/backups/rudder"
+%else
+	echo "INFO: No init script / cron script backup necessary on AIX builds yet. Skipping...
+%endif
 fi
 
 %post -n rudder-agent
@@ -553,6 +554,7 @@ if [ $1 -eq 0 ]; then
     fi
   done
 
+%if "%{?_os}" != "aix"
   # Remove the cron script we create at installation to prevent mail
   # flooding, re-installation surprises, and general system garbage.
   rm -f /etc/cron.d/rudder-agent
@@ -560,6 +562,9 @@ if [ $1 -eq 0 ]; then
   # Make sure that Rudder agent specific files have been removed
   rm -f /etc/init.d/rudder-agent
   rm -f /etc/default/rudder-agent
+%endif
+
+  # Remove UUID in any case
   rm -f /opt/rudder/etc/uuid.hive
 fi
 


### PR DESCRIPTION
...ent

Ticket: http://www.rudder-project.org/redmine/issues/4801

To be merged in 2.10_aix
