### PR TITLE
Bug 4830/rudder agent package build fails on debian type os because it can t find fusioninventory code

### DIFF
--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -15,7 +15,7 @@ configure: configure-stamp
 configure-stamp:
 	dh_testdir
 	# Add here commands to configure the package.
-	cd SOURCES && ./perl-prepare.sh
+	cd SOURCES && ./perl-prepare.sh $(CURDIR)/SOURCES/fusioninventory-agent
 	cd SOURCES/cfengine-source && ./configure --prefix=/opt/rudder --with-workdir=/var/rudder/cfengine-community --enable-static=yes --enable-shared=no
 
 	touch configure-stamp


### PR DESCRIPTION
See http://www.rudder-project.org/redmine/issues/4830
