### PR TITLE
Fixes #4872 - Add exclusion for ignore_interfaces.st if already existing during rudder-upgrade

### DIFF
--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -574,10 +574,16 @@ sed -i 's/^rudder.ptlib.git.refs.path *=/rudder.techniqueLibrary.git.refs.path=/
 # Upgrade system Techniques - always do this!
 SRCTECHDIR=/opt/rudder/share/techniques/system/
 TRGTECHDIR=/var/rudder/configuration-repository/techniques/system/
+FILE_TO_EXCLUDE="ignore_interfaces.st"
+FILEPATH_TO_EXCLUDE="${TRGTECHDIR}common/1.0"
+RSYNC_EXCLUDE_OPT=""
 
 if [ -d ${SRCTECHDIR} -a -d ${TRGTECHDIR} ]; then
 	if ! diff -Naur /opt/rudder/share/techniques/system/ /var/rudder/configuration-repository/techniques/system/ > /dev/null; then
-		rsync --delete -rptgoq /opt/rudder/share/techniques/system/ /var/rudder/configuration-repository/techniques/system/
+        if [ -f ${FILEPATH_TO_EXCLUDE}/${FILE_TO_EXCLUDE} ]; then
+           RSYNC_EXCLUDE_OPT="--exclude=${FILE_TO_EXCLUDE}"
+        fi
+		rsync --delete -rptgoq ${RSYNC_EXCLUDE_OPT} /opt/rudder/share/techniques/system/ /var/rudder/configuration-repository/techniques/system/
 		cd /var/rudder/configuration-repository/techniques/ && git add -A system/ && git commit -m "Upgrade system Techniques - automatically done by rudder-upgrade script"
 		# For every upgrade, we schedule a Technique reloading REST call on the next CFEngine run
 		echo "A Technique library reload is needed and has been scheduled."


### PR DESCRIPTION
Fixes #4872 - Add exclusion for ignore_interfaces.st if already existing during rudder-upgrade

cf http://www.rudder-project.org/redmine/issues/4872
