### PR TITLE
Fixes #4875 - Remove javadoc folder from jetty

### DIFF
--- a/rudder-jetty/SOURCES/Makefile
+++ b/rudder-jetty/SOURCES/Makefile
@@ -32,6 +32,8 @@ localdepends: ./jetty7
 	tar xzf $(TMP_DIR)/jetty.tgz -C $(TMP_DIR)
 	mv $(TMP_DIR)/jetty-hightide-$(JETTY_RELEASE).v$(DATE_RELEASE) ./jetty7
 	rm -rf $(TMP_DIR)
+	# Remove javadoc which is a waste of 34M on production
+	rm -rf ./jetty7/javadoc
 
 	# Change default log directory for jetty
 	sed -i 's/default=\".\/logs\"/default=\"\/var\/log\/rudder\/webapp\"/g' ./jetty7/etc/jetty-logging.xml


### PR DESCRIPTION
Fixes #4875 - Remove javadoc folder from jetty

cf http://www.rudder-project.org/redmine/issues/4875
