### PR TITLE
Fixes #4865: Correct check_rudder_agent not to use init.d on AIX and opt...

### DIFF
--- a/rudder-agent/SOURCES/check-rudder-agent
+++ b/rudder-agent/SOURCES/check-rudder-agent
@@ -22,10 +22,12 @@ set -e
 # Ensure our PATH includes Rudder's bin dir (for uuidgen on AIX in particular)
 export PATH=/opt/rudder/bin/:$PATH
 
+# Variables
 BACKUP_DIR=/var/backups/rudder/
+OS_FAMILY=$(uname -s)
 
 # If we are on AIX, use alternative commands and options
-if [ "z$(uname -s)" = "zAIX" ]; then
+if [ "z${OS_FAMILY}" = "zAIX" ]; then
   CP_A="cp -hpPr"
   PS_OPTIONS="-ef"
 else
@@ -34,7 +36,7 @@ else
 fi
 
 echo_n() {
-  if [ "z$(uname -s)" = "zAIX" ]; then
+  if [ "z${OS_FAMILY}" = "zAIX" ]; then
     /usr/bin/echo "$*\c"
   else
     echo -n $*
@@ -109,7 +111,9 @@ fi
 if [ ${NB_CF_PROCESS_RUNNING} -gt 8 ]; then
   echo_n "WARNING: Too many instance of CFEngine processes running. Killing them, and purging the TokyoCabinet database..."
   echo "${CF_PROCESS_RUNNING}" | awk 'BEGIN { OFS=" "} {print $2 }' | xargs kill -9 || true
-  /etc/init.d/rudder-agent forcestop || true
+  if [ "z${OS_FAMILY}" != "zAIX" ]; then
+    /etc/init.d/rudder-agent forcestop || true
+  fi
   clean_cf_lock_files
   echo " Done"
 fi
@@ -194,7 +198,7 @@ check_and_fix_cfengine_processes
 check_and_fix_cf_lock
 
 # The following files are not present on AIX systems
-if [ "z$(uname -s)" != "zAIX" ]; then
+if [ "z${OS_FAMILY}" != "zAIX" ]; then
   check_and_fix_specific_rudder_agent_file /etc/init.d/rudder-agent init
   check_and_fix_specific_rudder_agent_file /etc/default/rudder-agent default
   check_and_fix_specific_rudder_agent_file /etc/cron.d/rudder-agent cron


### PR DESCRIPTION
...imise os family detection (call uname only one time)

Ticket: http://www.rudder-project.org/redmine/issues/4865

To be merged in 2.10
