### PR TITLE
Fixes #4916: Use autogen.sh on rudder-agent cfengine compilation when no...

### DIFF
--- a/rudder-agent/SOURCES/.dependencies
+++ b/rudder-agent/SOURCES/.dependencies
@@ -1,7 +1,7 @@
-SLES11:gcc openssl-devel bison flex pcre-devel libdb-4_5-devel zlib-devel libbz2-devel
-SLES10:gcc openssl-devel bison flex pcre-devel db42-devel zlib-devel
-RHEL3:gcc openssl-devel bison flex pcre-devel make byacc zlib-devel bzip2-devel kernel-utils
-RHEL5:gcc openssl-devel bison flex pcre-devel make db4-devel byacc zlib-devel bzip2-devel
-RHEL6:gcc openssl-devel bison flex pcre-devel make db4-devel byacc tokyocabinet-devel
-FEDORA18:gcc openssl-devel bison flex pcre-devel make db4-devel byacc tokyocabinet-devel
-FEDORA20:gcc openssl-devel bison flex pcre-devel make db4-devel byacc tokyocabinet-devel
+SLES11:gcc openssl-devel bison flex autoconf automake libtool pcre-devel zlib-devel libbz2-devel
+SLES10:gcc openssl-devel bison flex autoconf automake libtool pcre-devel zlib-devel
+RHEL3:gcc openssl-devel bison flex autoconf automake libtool pcre-devel make byacc zlib-devel bzip2-devel kernel-utils
+RHEL5:gcc openssl-devel bison flex autoconf automake libtool pcre-devel make byacc zlib-devel bzip2-devel
+RHEL6:gcc openssl-devel bison flex autoconf automake libtool pcre-devel make byacc
+FEDORA18:gcc openssl-devel bison flex autoconf automake libtool pcre-devel make byacc
+FEDORA20:gcc openssl-devel bison flex autoconf automake libtool pcre-devel make byacc

--- a/rudder-agent/SOURCES/patches/DEBIAN_8/0001-use-lmdb-from-packages.patch
+++ b/rudder-agent/SOURCES/patches/DEBIAN_8/0001-use-lmdb-from-packages.patch
@@ -1,68 +1,18 @@
 diff -Naurw debian/control debian-new/control
---- debian/control	2014-05-13 12:20:49.811777659 +0200
-+++ debian/control	2014-05-13 12:19:51.151566236 +0200
+--- debian/control	2014-06-02 13:13:37.358327860 +0200
++++ debian/control	2014-06-02 13:11:25.266094413 +0200
 @@ -2,7 +2,7 @@
  Section: admin
  Priority: extra
  Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
--Build-Depends: debhelper (>= 7), libssl-dev, bison, gcc, flex, libpcre3-dev, libpam0g-dev
-+Build-Depends: debhelper (>= 7), libssl-dev, bison, gcc, flex, libpcre3-dev, libpam0g-dev, liblmdb-dev
+-Build-Depends: debhelper (>= 7), libssl-dev, bison, gcc, flex, autoconf, automake, libtool, libpcre3-dev, libpam0g-dev
++Build-Depends: debhelper (>= 7), libssl-dev, bison, gcc, flex, autoconf, automake, libtool, libpcre3-dev, libpam0g-dev, liblmdb-dev
  Standards-Version: 3.8.0
  Homepage: http://www.rudder-project.org
  
-diff -Naurw debian/rules debian-new/rules
---- debian/rules	2014-05-13 14:00:36.748017941 +0200
-+++ debian/rules	2014-05-13 12:19:51.151566236 +0200
-@@ -14,17 +14,9 @@
- configure: configure-stamp
- configure-stamp:
- 	dh_testdir
--	# dh_prep has been moved from 'install' target since we need to build LMDB first
--	dh_prep
- 	# Add here commands to configure the package.
- 	cd SOURCES && ./perl-prepare.sh
--	# Compile the LMDB library and install it in /opt/rudder
--	# LMDB source code does not know how to create destination folders, do it ourselves
--	for i in bin lib include man/man1; do mkdir -p $(CURDIR)/debian/tmp/opt/rudder/$$i; done
--	cd SOURCES/lmdb-source/libraries/liblmdb && make
--	cd SOURCES/lmdb-source/libraries/liblmdb && make install prefix=/opt/rudder DESTDIR=$(CURDIR)/debian/tmp
--	# Prepare CFEngine 3.6.x build with defined path of LMDB
--	cd SOURCES/cfengine-source && ./configure --prefix=/opt/rudder --with-workdir=/var/rudder/cfengine-community --enable-static=yes --enable-shared=no --with-lmdb=$(CURDIR)/debian/tmp/opt/rudder
-+	cd SOURCES/cfengine-source && ./configure --prefix=/opt/rudder --with-workdir=/var/rudder/cfengine-community --enable-static=yes --enable-shared=no
- 
- 	touch configure-stamp
- 
-@@ -55,6 +47,7 @@
- install: build
- 	dh_testdir
- 	dh_testroot
-+	dh_prep
- 	dh_installdirs
- 
- 	# Add here commands to install the package into debian/tmp
-@@ -86,9 +79,6 @@
- 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES initial-promises /opt/rudder/share
- 	# Install an empty uuid.hive file before generating an uuid
- 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ uuid.hive /opt/rudder/etc/
--	# Install /etc/ld.so.conf.d/rudder.conf in order to use libraries contain
--	# in /opt/rudder/lib like LMDB
--	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder.conf /etc/ld.so.conf.d
- 	# Install a verification script for cron
- 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ check-rudder-agent /opt/rudder/bin/
- 	# Install script to get local processes on VZ systems
-@@ -101,7 +91,7 @@
- 	dh_compress
- 	dh_fixperms
- #	dh_perl
--	dh_makeshlibs
-+#	dh_makeshlibs
- 	dh_installdeb
- 	dh_shlibdeps
- 	dh_gencontrol
-
-diff -Naurw debian/control debian-new/control
---- debian/postinst	2014-05-13 14:12:43.838564255 +0200
-+++ debian/postinst	2014-05-13 12:19:51.151566236 +0200
+diff -Naurw debian/postinst debian-new/postinst
+--- debian/postinst	2014-06-02 13:13:37.358327860 +0200
++++ debian/postinst	2014-06-02 13:11:25.266094413 +0200
 @@ -33,9 +33,6 @@
  		fi
      fi
@@ -73,3 +23,54 @@ diff -Naurw debian/control debian-new/control
  		# Copy new binaries to workdir, make sure daemons are stopped first
  
  		# Set a "lock" to avoid CFEngine being restarted during the upgrade process
+diff -Naurw debian/rules debian-new/rules
+--- debian/rules	2014-06-02 13:13:37.358327860 +0200
++++ debian/rules	2014-06-02 13:12:18.010187780 +0200
+@@ -14,19 +14,12 @@
+ configure: configure-stamp
+ configure-stamp:
+ 	dh_testdir
+-	# dh_prep has been moved from 'install' target since we need to build LMDB first
+-	dh_prep
+ 	# Add here commands to configure the package.
+ 	cd SOURCES && ./perl-prepare.sh $(CURDIR)/SOURCES/fusioninventory-agent
+-	# Compile the LMDB library and install it in /opt/rudder
+-	# LMDB source code does not know how to create destination folders, do it ourselves
+-	for i in bin lib include man/man1; do mkdir -p $(CURDIR)/debian/tmp/opt/rudder/$$i; done
+-	cd SOURCES/lmdb-source/libraries/liblmdb && make
+-	cd SOURCES/lmdb-source/libraries/liblmdb && make install prefix=/opt/rudder DESTDIR=$(CURDIR)/debian/tmp
+ 	# If there is no configure, bootstrap with autogen.sh first
+ 	cd SOURCES/cfengine-source && [ ! -x ./configure ] && NO_CONFIGURE=1 ./autogen.sh
+ 	# Prepare CFEngine 3.6.x build with defined path of LMDB
+-	cd SOURCES/cfengine-source && ./configure --prefix=/opt/rudder --with-workdir=/var/rudder/cfengine-community --enable-static=yes --enable-shared=no --with-lmdb=$(CURDIR)/debian/tmp/opt/rudder
++	cd SOURCES/cfengine-source && ./configure --prefix=/opt/rudder --with-workdir=/var/rudder/cfengine-community --enable-static=yes --enable-shared=no
+ 
+ 	touch configure-stamp
+ 
+@@ -57,6 +50,7 @@
+ install: build
+ 	dh_testdir
+ 	dh_testroot
++	dh_prep
+ 	dh_installdirs
+ 
+ 	# Add here commands to install the package into debian/tmp
+@@ -88,9 +82,6 @@
+ 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES initial-promises /opt/rudder/share
+ 	# Install an empty uuid.hive file before generating an uuid
+ 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ uuid.hive /opt/rudder/etc/
+-	# Install /etc/ld.so.conf.d/rudder.conf in order to use libraries contain
+-	# in /opt/rudder/lib like LMDB
+-	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder.conf /etc/ld.so.conf.d
+ 	# Install a verification script for cron
+ 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ check-rudder-agent /opt/rudder/bin/
+ 	# Install script to get local processes on VZ systems
+@@ -105,7 +96,7 @@
+ 	dh_compress
+ 	dh_fixperms
+ #	dh_perl
+-	dh_makeshlibs
++#	dh_makeshlibs
+ 	dh_installdeb
+ 	dh_shlibdeps
+ 	dh_gencontrol

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -84,7 +84,7 @@ Patch1: fix-missing-headers
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 #Generic requirement
-BuildRequires: gcc openssl-devel bison flex pcre-devel
+BuildRequires: gcc openssl-devel bison flex pcre-devel autoconf automake libtool
 Requires: pcre openssl
 
 # Specific requirements
@@ -206,6 +206,11 @@ cd %{_sourcedir}/cfengine-source
 %else
 %define lmdb_arg ""
 %endif
+
+# If there is no configure, bootstrap with autogen.sh first
+if [ ! -x ./configure ]; then
+  NO_CONFIGURE=1 ./autogen.sh
+fi
 
 ./configure --build=%_target --prefix=%{rudderdir} --with-workdir=%{ruddervardir}/cfengine-community --enable-static=yes --enable-shared=no %{lmdb_arg}
 

--- a/rudder-agent/debian/control
+++ b/rudder-agent/debian/control
@@ -2,7 +2,7 @@ Source: rudder-agent
 Section: admin
 Priority: extra
 Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
-Build-Depends: debhelper (>= 7), libssl-dev, bison, gcc, flex, libpcre3-dev, libpam0g-dev
+Build-Depends: debhelper (>= 7), libssl-dev, bison, gcc, flex, autoconf, automake, libtool, libpcre3-dev, libpam0g-dev
 Standards-Version: 3.8.0
 Homepage: http://www.rudder-project.org
 

--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -23,6 +23,8 @@ configure-stamp:
 	for i in bin lib include man/man1; do mkdir -p $(CURDIR)/debian/tmp/opt/rudder/$$i; done
 	cd SOURCES/lmdb-source/libraries/liblmdb && make
 	cd SOURCES/lmdb-source/libraries/liblmdb && make install prefix=/opt/rudder DESTDIR=$(CURDIR)/debian/tmp
+	# If there is no configure, bootstrap with autogen.sh first
+	cd SOURCES/cfengine-source && [ -x ./configure ] || NO_CONFIGURE=1 ./autogen.sh
 	# Prepare CFEngine 3.6.x build with defined path of LMDB
 	cd SOURCES/cfengine-source && ./configure --prefix=/opt/rudder --with-workdir=/var/rudder/cfengine-community --enable-static=yes --enable-shared=no --with-lmdb=$(CURDIR)/debian/tmp/opt/rudder
 


### PR DESCRIPTION
... configure script is usable

Ticket: http://www.rudder-project.org/redmine/issues/4916

To be merged in 2.11
