### PR TITLE
Fixes #5054: Make AIX depend on LMDB too instead of TokyoCabinet

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -135,13 +135,9 @@ Requires: pmtools
 %define is_lmdb_here false
 %endif
 
-# AIX builds support TokyoCabinet via M. Perzl's
-# packages.
-# cf http://www.perzl.org/aix/
+## 4 - AIX: No LMDB yet
 %if "%{?_os}" == "aix"
-BuildRequires: tokyocabinet-devel
-Requires: tokyocabinet
-%define is_tokyocabinet_here true
+%define is_lmdb_here false
 %endif
 
 %define install_command        install


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5054

To be merged in 2.11
