### PR TITLE
Fixes #5102: Stop packaging jetty-init-rudder.patch (useless file)

### DIFF
--- a/rudder-jetty/SPECS/rudder-jetty.spec
+++ b/rudder-jetty/SPECS/rudder-jetty.spec
@@ -57,7 +57,6 @@ Source3: rudder-jetty.conf
 Source4: rudder-jetty
 
 Patch1: jetty-init-sles.patch
-Patch2: jetty-init-rudder.patch
 
 # Prevent rpmbuild to use 64 bits libraries just because of the presence
 # of one 64 bits binary in the jetty archive.


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5102

To be merged in 2.11
