### PR TITLE
Fixes #5115: Make rudder-agent-thin able to operate even when rudder-age...

### DIFF
--- a/rudder-agent-thin/SOURCES/Makefile
+++ b/rudder-agent-thin/SOURCES/Makefile
@@ -59,7 +59,7 @@ build-sources-stamp: fetch-sources-stamp rudder-agent.make
 
 localclean: rudder-agent.make
 	$(MAKE) -f rudder-agent.make localclean
-	xargs -a rudder-agent.list -d'\n' -I file rm -f ../file
+	xargs -a rudder-agent.list -d'\n' -I file rm -f ../file || echo "No rudder-agent.list, skipping rsync'ed files cleanup."
 	rm -rf ../SPECS ../debian
 	rm -f rudder-agent.list
 	rm -f fetch-sources-stamp


### PR DESCRIPTION
...nt.list does not exist

Ticket: http://www.rudder-project.org/redmine/issues/5115

To be merged in 2.11
