### PR TITLE
Fixes #5138: Change session path to '/' so session cookies can be shared

### DIFF
--- a/rudder-webapp/SOURCES/rudder.xml
+++ b/rudder-webapp/SOURCES/rudder.xml
@@ -8,4 +8,12 @@
 
 	<Set name="extraClasspath"></Set>
 
+	<!-- We need to change the jetty SessionPath so we can share the cookie between Rudder, ncf and ncf-builder so they can authenticate using session cookie.
+	     Using / make the cookie shared on all those 3 applications.
+	 -->
+	<Call name="setInitParameter">
+		<Arg>org.eclipse.jetty.servlet.SessionPath</Arg>
+		<Arg>/</Arg>
+	</Call>
+
 </Configure>


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/5138

We need to change the jetty context so we can share the cookie between Rudder, ncf and ncf-builder so they can authenticate using session cookie

Using / make the cookie shared on all those 3 applications
