### PR TITLE
Fixes #5162: Depend on Python during ncf-api-virtualenv build

### DIFF
--- a/ncf-api-virtualenv/SOURCES/.dependencies
+++ b/ncf-api-virtualenv/SOURCES/.dependencies
@@ -1,2 +1,7 @@
-SLES11:gcc
-SLES10:gcc
+SLES10:python
+SLES11:python
+RHEL3:python
+RHEL5:python
+RHEL6:python
+FEDORA18:python
+FEDORA20:python

--- a/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
+++ b/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
@@ -73,6 +73,7 @@ AutoReq: 0
 AutoProv: 0
 
 # Add Requires here - order is important
+BuildRequires: python
 Requires: python ncf
 
 # We need mod_wsgi to use ncf builder

--- a/ncf-api-virtualenv/debian/control
+++ b/ncf-api-virtualenv/debian/control
@@ -2,7 +2,7 @@ Source: ncf-api-virtualenv
 Section: admin
 Priority: extra
 Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
-Build-Depends: debhelper (>= 7)
+Build-Depends: debhelper (>= 7), python
 Standards-Version: 3.8.0
 Homepage: http://www.ncf.io
 


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5162

To be merged in 2.11
