### PR TITLE
Fixes #5163: Sync ncf-api-virtualenv package between specfile and debian

### DIFF
--- a/ncf-api-virtualenv/debian/rules
+++ b/ncf-api-virtualenv/debian/rules
@@ -24,7 +24,7 @@ build-stamp: configure-stamp
 	cd SOURCES && python virtualenv.py ncf-api-virtualenv
 
 	# Get all requirements via pip
-	cd SOURCES && ncf-api-virtualenv/bin/pip install -r requirements.txt
+	cd SOURCES && ncf-api-virtualenv/bin/pip install -r rudder-sources/ncf/api/requirements.txt
 
 	# Clean up unwanted binaries
 	cd SOURCES && for i in easy_install python pip; do rm -f ncf-api-virtualenv/bin/${i}*; done


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5163

To be merged in 2.11
