### PR TITLE
Fixes #5165: Fix ncf-api-virtualenv cleaning part in Debian

### DIFF
--- a/ncf-api-virtualenv/debian/rules
+++ b/ncf-api-virtualenv/debian/rules
@@ -27,7 +27,7 @@ build-stamp: configure-stamp
 	cd SOURCES && ncf-api-virtualenv/bin/pip install -r rudder-sources/ncf/api/requirements.txt
 
 	# Clean up unwanted binaries
-	cd SOURCES && for i in easy_install python pip; do rm -f ncf-api-virtualenv/bin/${i}*; done
+	cd SOURCES && for i in easy_install python pip; do rm -f ncf-api-virtualenv/bin/$${i}*; done
 
 	touch $@
 


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5165

To be merged in 2.11
