### PR TITLE
Fixes #5167: Use pip 1.2.1 on SLES to prevent OpenSSL related problems

### DIFF
--- a/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
+++ b/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
@@ -112,6 +112,14 @@ cd %{_sourcedir}
 # Build Virtualenv
 python virtualenv.py %{real_name}
 
+## SLES
+%if 0%{?sles}
+# Using a recent pip on SLES is not possible due to
+# bad interaction between pip and an old OpenSSL.
+# See http://stackoverflow.com/questions/17416938/pip-can-not-install-anything
+%{real_name}/bin/easy_install pip==1.2.1
+%endif
+
 # Get all requirements via pip
 %{real_name}/bin/pip install -r %{_sourcedir}/rudder-sources/ncf/api/requirements.txt
 


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5167

To be merged in 2.11
