### PR TITLE
Fixes #5168: Fix ncf-api-virtualenv venv installation in SPECfile

### DIFF
--- a/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
+++ b/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
@@ -141,7 +141,7 @@ mkdir -p %{buildroot}%{apache_vhost_dir}/
 
 # Files
 
-cp -r %{real_name}/* %{buildroot}%{installdir}/
+cp -r %{_sourcedir}/%{real_name}/* %{buildroot}%{installdir}/
 
 install -m 644 %{SOURCE1} %{buildroot}%{installdir}/
 install -m 644 %{SOURCE2} %{buildroot}%{apache_vhost_dir}/


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5168

To be merged in 2.11
