### PR TITLE
Fixes #5199: Add net-tools to rudder-agent dependencies

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -86,7 +86,7 @@ Requires: crontabs
 
 ## For SLES
 %if 0%{?sles_version}
-Requires: cron
+Requires: cron net-tools
 %endif
 
 # dmiecode is provided in the "dmidecode" package on EL4+ and on kernel-utils

--- a/rudder-agent/debian/control
+++ b/rudder-agent/debian/control
@@ -1,3 +1,4 @@
+
 Source: rudder-agent
 Section: admin
 Priority: extra
@@ -8,7 +9,7 @@ Homepage: http://www.rudder-project.org
 
 Package: rudder-agent
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, uuid-runtime, dmidecode, cron
+Depends: ${shlibs:Depends}, ${misc:Depends}, uuid-runtime, dmidecode, cron, net-tools
 # The dependencies below are defined in order to use rudder-agent
 # for the server. This will add capabilities to send inventories
 # from the server itself.


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5199

To be merged in 2.6
