### PR TITLE
Fixes #5221: Cleanup ncf post hooks and make the output of the commands ...

### DIFF
--- a/rudder-webapp/SOURCES/post.write_technique.commit.sh
+++ b/rudder-webapp/SOURCES/post.write_technique.commit.sh
@@ -23,15 +23,18 @@
 #
 
 # Variables
-DESTINATION_PATH=$1
-TECHNIQUE=$2
+
+DESTINATION_PATH=${1}
+TECHNIQUE=${2}
 
 # Main
 
+## Set necessary umask to prevent permission issues (mode 770)
 umask 007
 
+## Operate on configuration-repository's git tree
 cd /var/rudder/configuration-repository
 
-git add ncf/50_techniques/$TECHNIQUE
-
-git commit -m "Commit ncf Techniques '$TECHNIQUE' in Rudder"
+## Commit the new Technique
+git add "ncf/50_techniques/${TECHNIQUE}"
+git commit -q -m "Commit ncf Technique \"${TECHNIQUE}\" in Rudder"


### PR DESCRIPTION
...silent unless an error happens to prevent log cluttering

Ticket: http://www.rudder-project.org/redmine/issues/5221

To be merged in 2.11

NOTE: This is only cleanup/comment code, no logic has been altered.
