### PR TITLE
Fixes #5229 - Adjust permissiosn on .git folder to permit ncf-api to commit

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -392,6 +392,7 @@ fi
 # Adjust permissions on /var/rudder/configuration-repository
 chgrp -R %{config_repository_group} /var/rudder/configuration-repository
 ## Add execution permission for ncf-api only on directories and files with user execution permission
+chmod -R u+rwX,g+rwsX %{ruddervardir}/configuration-repository/.git
 chmod -R u+rwX,g+rwsX %{ruddervardir}/configuration-repository/ncf
 chmod -R u+rwX,g+rwsX %{ruddervardir}/configuration-repository/techniques
 ## Add execution permission for ncf-apo on pre/post-hooks

--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -128,6 +128,7 @@ case "$1" in
   # Adjust permissions on /var/rudder/configuration-repository
   chgrp -R rudder /var/rudder/configuration-repository
   ## Add execution permission for ncf-api only on directories and files with user execution permission
+  chmod -R u+rwX,g+rwsX /var/rudder/configuration-repository/.git
   chmod -R u+rwX,g+rwsX /var/rudder/configuration-repository/ncf
   chmod -R u+rwX,g+rwsX /var/rudder/configuration-repository/techniques
   ## Add execution permission for ncf-apo on pre/post-hooks


### PR DESCRIPTION
Fixes #5229 - Adjust permissiosn on .git folder to permit ncf-api to commit

cf http://www.rudder-project.org/redmine/issues/5229
