### PR TITLE
Fixes #5160 - Use files wih '.conf' extension for Apache vhost

### DIFF
--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -59,7 +59,7 @@ case "$1" in
   htpasswd -bc /opt/rudder/etc/htpasswd-webdav rudder rudder >/dev/null 2>&1
 
   # Move old virtual hosts out of the way
-  for OLD_VHOST in rudder-default rudder-default-ssl; do
+  for OLD_VHOST in rudder-default rudder-default-ssl rudder-vhost rudder-vhost-ssl; do
     if [ -f /etc/apache2/sites-available/${OLD_VHOST} ]; then
       echo -n "INFO: An old rudder virtual host file has been detected (${OLD_VHOST}), it will be moved to /var/backups."
       mkdir -p /var/backups

--- a/rudder-webapp/debian/rules
+++ b/rudder-webapp/debian/rules
@@ -80,10 +80,8 @@ binary-arch: install
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-core/src/main/resources/ reportsInfo.xml /opt/rudder/etc/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/ load-page/  /opt/rudder/share/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/ rudder-apache-common.conf /opt/rudder/etc/
-	cp $(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/rudder-vhost.conf $(CURDIR)/BUILD/rudder-vhost
-	cp $(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/rudder-vhost-ssl.conf $(CURDIR)/BUILD/rudder-vhost-ssl
-	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-vhost /etc/apache2/sites-available/
-	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-vhost-ssl /etc/apache2/sites-available/
+	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/ rudder-vhost.conf /etc/apache2/sites-available/
+	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-web/src/main/resources/ rudder-vhost-ssl.conf /etc/apache2/sites-available/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder.xml /opt/rudder/share/webapps/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-networks.conf /opt/rudder/etc/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-passwords.conf /opt/rudder/etc/


### PR DESCRIPTION
Fixes #5160 - Use files wih '.conf' extension for Apache vhost

cf http://www.rudder-project.org/redmine/issues/5160
