### PR TITLE
Fixes #5274 - Add ncf.conf as a config file in order to not replace its content at each upgrade of package

### DIFF
--- a/ncf/SPECS/ncf.spec
+++ b/ncf/SPECS/ncf.spec
@@ -109,6 +109,7 @@ rm -rf %{buildroot}
 %files -n ncf
 %defattr(-, root, root, 0755)
 %{installdir}/ncf/
+%config(noreplace) %{installdir}/ncf/tree/ncf.conf
 %{bindir}/ncf
 
 #=================================================

--- a/ncf/debian/conffiles
+++ b/ncf/debian/conffiles
@@ -1,0 +1,1 @@
+/usr/share/ncf/tree/ncf.conf


### PR DESCRIPTION
Fixes #5274 - Add ncf.conf as a config file in order to not replace its content at each upgrade of package

cf http://www.rudder-project.org/redmine/issues/5274
