### PR TITLE
Fixes #5355 - Move WSGI socket in a generic folder instead of a wrong location on RHEL

### DIFF
--- a/ncf-api-virtualenv/SOURCES/ncf-api-virtualenv.conf
+++ b/ncf-api-virtualenv/SOURCES/ncf-api-virtualenv.conf
@@ -5,6 +5,7 @@ Alias /ncf-builder /usr/share/ncf/builder
 
 ## Set up a WSGI serving process named ncf_api_flask_app
 WSGIDaemonProcess ncf_api_flask_app threads=5 user=ncf-api-venv
+WSGISocketPrefix /var/run/wsgi
 
 ## Make the API available on /ncf using the .wsgi file bundled with the package
 WSGIScriptAlias /ncf /usr/share/ncf-api-virtualenv/ncf_api_flask_app.wsgi


### PR DESCRIPTION
Fixes #5355 - Move WSGI socket in a generic folder instead of a wrong location on RHEL

cf http://www.rudder-project.org/redmine/issues/5355
