### PR TITLE
Fixes #5370: Use /srv/www as Apache DocumentRoot on SLES

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -284,6 +284,11 @@ if [ ! -f /opt/rudder/etc/ssl/rudder-webapp.crt ] || [ ! -f /opt/rudder/etc/ssl/
 	echo " Done"
 fi
 
+%if 0%{?sles_version}
+# On SLES, change the Apache DocumentRoot to the OS default, unless it has already been modified
+sed -i "s%^DocumentRoot /var/www$%DocumentRoot /srv/www%" %{rudderdir}/etc/rudder-apache-common.conf
+%endif
+
 echo -n "INFO: Starting Apache HTTPd..."
 /sbin/service %{apache} start >/dev/null 2>&1
 echo " Done"


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5370

To be merged in 2.10
