### PR TITLE
Fixes #5380 - Remove whitespace in debian/contol file of rudder-agent

### DIFF
--- a/rudder-agent/debian/control
+++ b/rudder-agent/debian/control
@@ -1,4 +1,3 @@
-
 Source: rudder-agent
 Section: admin
 Priority: extra


### PR DESCRIPTION
Fixes #5380 - Remove whitespace in debian/contol file of rudder-agent

cf http://www.rudder-project.org/redmine/issues/5380
