### PR TITLE
Fixes #5386: rudder-agent 2.11.{0,1} ignore duplicate lines in data file...

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -42,6 +42,7 @@ localdepends: ./initial-promises ./detect_os.sh ./files ./fusioninventory-agent 
 	$(PATCH) -d ./cfengine-source -p1 < ./patches/cfengine/0002-explicitely-use-pthreads-during-lmdb-presence-detection.patch
 	$(PATCH) -d ./cfengine-source -p1 < ./patches/cfengine/0003-fix-fprintf-usage-on-old-gcc-versions.patch
 	$(PATCH) -d ./cfengine-source -p1 < ./patches/cfengine/0004-fix-zero-sized-files-from-template-when-nolocks.patch
+	$(PATCH) -d ./cfengine-source -p1 < ./patches/cfengine/0005-fix-readstringarrayidx-duplicate-lines.patch
 	# Bootstrap the package using autogen before compilation
 	cd cfengine-source && NO_CONFIGURE=1 ./autogen.sh
 

--- a/rudder-agent/SOURCES/patches/cfengine/0005-fix-readstringarrayidx-duplicate-lines.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/0005-fix-readstringarrayidx-duplicate-lines.patch
@@ -1,0 +1,315 @@
+Rudder issue: http://www.rudder-project.org/redmine/issues/5386
+
+Please see https://dev.cfengine.com/issues/6466 for details.
+
+From b796914262747321fbd9fca67da5f2983ffdf039 Mon Sep 17 00:00:00 2001
+From: Edward Welbourne <edward.welbourne@cfengine.com>
+Date: Fri, 8 Aug 2014 11:31:00 +0200
+Subject: [PATCH 1/2] Rewrote RlistFromSplitString() to not limit fragment
+ lengths.
+
+It previously restricted the sizes of fragments to 1024 bytes,
+CF_MAXVARSIZE; it now uses a dynamically-sized buffer.  Also, instead
+of appending fragments to the Rlist, prepend them and reverse the list
+just before returning it; this reduces an O(len^2) to an O(len).
+---
+ libpromises/rlist.c | 67 ++++++++++++++++++++++++++++-------------------------
+ 1 file changed, 35 insertions(+), 32 deletions(-)
+
+diff --git a/libpromises/rlist.c b/libpromises/rlist.c
+index 4c57cee..f0e6d60 100644
+--- a/libpromises/rlist.c
++++ b/libpromises/rlist.c
+@@ -842,45 +842,51 @@ void RlistDestroyEntry(Rlist **liststart, Rlist *entry)
+ 
+ /*******************************************************************/
+ 
+-/*
+- * Copies from <from> to <to>, writing up to <len> bytes, stopping
+- * before the first <sep>.
++/* Copies a <sep>-delimited unit from <from> into a new entry in <to>.
+  *
+- * \<sep> is not counted as the separator, but copied to <to> as <sep>.
+- * Any other escape sequences are not supported.
++ * \<sep> is not counted as the separator, but copied to the new entry
++ * as <sep>.  No other escape sequences are supported.
+  *
+- * Returns the number of bytes read out of from; this may be more than
+- * the number written into to (which is at most len, including the
+- * terminating '\0').
++ * Returns the number of bytes read out of <from>; this may be more
++ * than the length of the new entry in <to>.  The new entry is
++ * prepended; the caller can reverse <to> once built.
+  */
+-static int SubStrnCopyChr(char *to, const char *from, int len, char sep)
++static size_t SubStrnCopyChr(Rlist **to, const char *from, char sep)
+ {
+-    char *sto = to;
+-    int count = 0;
+     assert(from && from[0]);
+ 
+-    for (const char *sp = from; sto - to < len - 1 && sp[0] != '\0'; sp++)
++    const char *end = from;
++    size_t escapes = 0;
++    while (end && end[0] && end[0] != sep)
+     {
+-        if (sp[0] == '\\' && sp[1] == sep)
+-        {
+-            *sto++ = *++sp;
+-            count += 2;
+-        }
+-        else if (sp[0] == sep)
++        end = strchr(end, sep);
++        assert(end == NULL || end[0] == sep);
++        if (end && end > from && end[-1] == '\\')
+         {
+-            break;
++            escapes++;
++            end++;
+         }
+-        else
++    }
++
++    size_t consume = (end == NULL) ? strlen(from) : (end - from);
++    assert(consume >= escapes);
++    char copy[1 + consume - escapes], *dst = copy;
++
++    for (const char *src = from; src[0] != '\0' && src[0] != sep; src++)
++    {
++        if (src[0] == '\\' && src[1] == sep)
+         {
+-            *sto++ = sp[0];
+-            count++;
++            src++; /* Skip over the backslash so we copy the sep */
+         }
++        dst++[0] = src[0];
+     }
+-    assert(sto - to < len);
+-    *sto = '\0';
++    assert(dst + 1 == copy + sizeof(copy));
++    *dst = '\0';
+ 
+-    assert(count <= strlen(from));
+-    return count;
++    /* Prepend to the list and reverse when done, costing O(len),
++     * instead of appending, which costs O(len**2). */
++    RlistPrependRval(to, RvalCopyScalar((Rval) { copy, RVAL_TYPE_SCALAR }));
++    return consume;
+ }
+ 
+ Rlist *RlistFromSplitString(const char *string, char sep)
+@@ -888,27 +894,24 @@ Rlist *RlistFromSplitString(const char *string, char sep)
+  * separate items.  Supports escaping separators - e.g. "\," isn't a
+  * separator, it contributes a simple "," in a list entry. */
+ {
+-    if (string == NULL)
++    if (string == NULL || string[0] == '\0')
+     {
+         return NULL;
+     }
+-
+     Rlist *liststart = NULL;
+-    char node[CF_MAXVARSIZE];
+ 
+     for (const char *sp = string; *sp != '\0';)
+     {
+-        sp += SubStrnCopyChr(node, sp, CF_MAXVARSIZE, sep);
++        sp += SubStrnCopyChr(&liststart, sp, sep);
+         assert(sp - string <= strlen(string));
+         if (*sp)
+         {
+             assert(*sp == sep && (sp == string || sp[-1] != '\\'));
+             sp++;
+         }
+-
+-        RlistAppendScalar(&liststart, node);
+     }
+ 
++    RlistReverse(&liststart);
+     return liststart;
+ }
+ 
+-- 
+2.0.3
+
+
+From 6e11153492f13ff2057101cb2d5e9726dad41f93 Mon Sep 17 00:00:00 2001
+From: Edward Welbourne <edward.welbourne@cfengine.com>
+Date: Thu, 7 Aug 2014 16:36:33 +0200
+Subject: [PATCH 2/2] redmine6466: preserve order in readstringarrayidx
+
+Reading the file's contents via a Set is harmless for the other
+read*array functions, since they use data from each line as the key,
+so naturally discard duplicates and have no other ordering than that
+of the keys themselves; however, for readstringarrayidx, the order of
+lines actually matters and duplicates are meaningful.  So convert
+BuildLineArray to use an Rlist instead of a StringSet (and iterator);
+and add an acceptance test (which was actually the hard part).
+---
+ libpromises/evalfunction.c                         |  12 +--
+ .../02_functions/readstringarrayidx_order.cf       | 113 +++++++++++++++++++++
+ 2 files changed, 118 insertions(+), 7 deletions(-)
+ create mode 100644 tests/acceptance/01_vars/02_functions/readstringarrayidx_order.cf
+
+diff --git a/libpromises/evalfunction.c b/libpromises/evalfunction.c
+index 2371815..9100614 100644
+--- a/libpromises/evalfunction.c
++++ b/libpromises/evalfunction.c
+@@ -6462,14 +6462,12 @@ static int BuildLineArray(EvalContext *ctx, const Bundle *bundle,
+                           const char *split, int maxent, DataType type,
+                           bool int_index)
+ {
+-    StringSet *lines = StringSetFromString(file_buffer, '\n');
+-
+-    StringSetIterator iter = StringSetIteratorInit(lines);
+-    char *line;
++    Rlist *lines = RlistFromSplitString(file_buffer, '\n');
+     int hcount = 0;
+ 
+-    while ((line = StringSetIteratorNext(&iter)) && hcount < maxent)
++    for (Rlist *it = lines; it && hcount < maxent; it = it->next)
+     {
++        char *line = RlistScalarValue(it);
+         size_t line_len = strlen(line);
+ 
+         if (line_len == 0 || (line_len == 1 && line[0] == '\r'))
+@@ -6477,7 +6475,7 @@ static int BuildLineArray(EvalContext *ctx, const Bundle *bundle,
+             continue;
+         }
+ 
+-        if (line[line_len - 1] ==  '\r')
++        if (line[line_len - 1] == '\r')
+         {
+             line[line_len - 1] = '\0';
+         }
+@@ -6556,7 +6554,7 @@ static int BuildLineArray(EvalContext *ctx, const Bundle *bundle,
+         line++;
+     }
+ 
+-    StringSetDestroy(lines);
++    RlistDestroy(lines);
+ 
+     return hcount;
+ }
+diff --git a/tests/acceptance/01_vars/02_functions/readstringarrayidx_order.cf b/tests/acceptance/01_vars/02_functions/readstringarrayidx_order.cf
+new file mode 100644
+index 0000000..4acc70c
+--- /dev/null
++++ b/tests/acceptance/01_vars/02_functions/readstringarrayidx_order.cf
+@@ -0,0 +1,113 @@
++#######################################################
++#
++# Acceptance test for RedMine 6466.
++#
++# Order and duplication in data should be preserved.
++# Based on an initial test by Neil Watson.
++#
++#######################################################
++
++body common control
++{
++      inputs => { "../../default.cf.sub" };
++      bundlesequence  => { default("$(this.promise_filename)") };
++      version => "1.0";
++}
++
++#######################################################
++
++bundle agent init
++{
++  vars:
++      # Note: order is deliberately one unlikely to happen
++      # automatically; and there are duplicates.
++      "file" slist => { "1 ;; other field 1",
++                        "2 ;; other field 2",
++                        "4 ;; other field 4",
++                        "8 ;; other field 8",
++                        "16 ;; other field 16",
++                        "2 ;; other field 2",
++                        "3 ;; other field 3",
++                        "6 ;; other field 6",
++                        "12 ;; other field 12",
++                        "9 ;; other field 9",
++                        "18 ;; other field 18",
++                        "3 ;; other field 3",
++                        "5 ;; other field 5",
++                        "10 ;; other field 10",
++                        "15 ;; other field 15",
++                        "5 ;; other field 5",
++                        "7 ;; other field 7",
++                        "14 ;; other field 14",
++                        "7 ;; other field 7",
++                        "0 ;; other field 0" };
++
++  files:
++      "$(G.testfile).orig.txt"
++        create        => 'true',
++        edit_defaults => empty,
++        edit_line     => insert_all_lines( "@{file}" );
++}
++
++#######################################################
++# Insert lines, preserving duplicates:
++
++bundle edit_line insert_all_lines(lines)
++{
++  vars:
++      "whole" string => join("
++", "lines");
++
++  insert_lines:
++      "$(whole)"
++      insert_type => "preserve_block";
++}
++
++#######################################################
++
++bundle agent test
++{
++  vars:
++      "num" int => readstringarrayidx("mylines",
++                                      "$(G.testfile).orig.txt",
++                                      "\s*#[^\n]*",
++                                      "\s*;;\s*",
++                                      50, 9999);
++
++      "file" slist => { "${mylines[0][0]} ;; ${mylines[0][1]}",
++                        "${mylines[1][0]} ;; ${mylines[1][1]}",
++                        "${mylines[2][0]} ;; ${mylines[2][1]}",
++                        "${mylines[3][0]} ;; ${mylines[3][1]}",
++                        "${mylines[4][0]} ;; ${mylines[4][1]}",
++                        "${mylines[5][0]} ;; ${mylines[5][1]}",
++                        "${mylines[6][0]} ;; ${mylines[6][1]}",
++                        "${mylines[7][0]} ;; ${mylines[7][1]}",
++                        "${mylines[8][0]} ;; ${mylines[8][1]}",
++                        "${mylines[9][0]} ;; ${mylines[9][1]}",
++                        "${mylines[10][0]} ;; ${mylines[10][1]}",
++                        "${mylines[11][0]} ;; ${mylines[11][1]}",
++                        "${mylines[12][0]} ;; ${mylines[12][1]}",
++                        "${mylines[13][0]} ;; ${mylines[13][1]}",
++                        "${mylines[14][0]} ;; ${mylines[14][1]}",
++                        "${mylines[15][0]} ;; ${mylines[15][1]}",
++                        "${mylines[16][0]} ;; ${mylines[16][1]}",
++                        "${mylines[17][0]} ;; ${mylines[17][1]}",
++                        "${mylines[18][0]} ;; ${mylines[18][1]}",
++                        "${mylines[19][0]} ;; ${mylines[19][1]}" };
++
++  files:
++      "$(G.testfile).copy.txt"
++        create        => 'true',
++        edit_defaults => empty,
++        edit_line     => insert_all_lines( "@{file}" );
++}
++
++#######################################################
++
++bundle agent check
++{
++  methods:
++      "any" usebundle => dcs_check_diff("$(G.testfile).copy.txt",
++                                        "$(G.testfile).orig.txt",
++                                        "$(this.promise_filename)");
++}
+-- 
+2.0.3
+


### PR DESCRIPTION
...s causing rpmPackageInstallation technique to ignore some configurations
