### PR TITLE
Fixes #5477: implement openvz support for rudder 2.11

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/0006-openvz-support.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/0006-openvz-support.patch
@@ -1,8 +1,7 @@
-diff --git a/cf-monitord/mon_processes.c b/cf-monitord/mon_processes.c
-index 7f5d70c..63a2ac9 100644
---- a/cf-monitord/mon_processes.c
-+++ b/cf-monitord/mon_processes.c
-@@ -74,7 +74,7 @@ static bool GatherProcessUsers(Item **userList, int *userListSz, int *numRootPro
+diff -r -auN cfengine-3.6.0/cf-monitord/mon_processes.c cfengine-3.6.0-patch1/cf-monitord/mon_processes.c
+--- cfengine-3.6.0/cf-monitord/mon_processes.c	2014-04-01 16:41:01.000000000 +0200
++++ cfengine-3.6.0-patch1/cf-monitord/mon_processes.c	2014-09-03 14:49:50.964464893 +0200
+@@ -74,7 +74,7 @@
      char pscomm[CF_BUFSIZE];
      char user[CF_MAXVARSIZE];
  
@@ -11,11 +10,10 @@ index 7f5d70c..63a2ac9 100644
  
      if ((pp = cf_popen(pscomm, "r", true)) == NULL)
      {
-diff --git a/libenv/sysinfo.c b/libenv/sysinfo.c
-index b91ca1f..7c897eb 100644
---- a/libenv/sysinfo.c
-+++ b/libenv/sysinfo.c
-@@ -471,6 +471,7 @@ static void GetNameInfo3(EvalContext *ctx)
+diff -r -auN cfengine-3.6.0/libenv/sysinfo.c cfengine-3.6.0-patch1/libenv/sysinfo.c
+--- cfengine-3.6.0/libenv/sysinfo.c	2014-06-11 16:15:15.000000000 +0200
++++ cfengine-3.6.0-patch1/libenv/sysinfo.c	2014-09-03 14:53:07.179129593 +0200
+@@ -470,6 +470,7 @@
                      found = true;
  
                      VSYSTEMHARDCLASS = (PlatformContext) i;
@@ -23,15 +21,27 @@ index b91ca1f..7c897eb 100644
                      EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "class", CLASSTEXT[i], CF_DATA_TYPE_STRING, "inventory,source=agent,attribute_name=OS type");
                      break;
                  }
-@@ -2340,6 +2341,7 @@ static void OpenVZ_Detect(EvalContext *ctx)
+@@ -2310,22 +2311,32 @@
+ #define OPENVZ_HOST_FILENAME "/proc/bc/0"
+ #define OPENVZ_GUEST_FILENAME "/proc/vz"
  /* path to the vzps binary */
- #define OPENVZ_VZPS_FILE "/bin/vzps"
+-#define OPENVZ_VZPS_FILE "/bin/vzps"
++#define OPENVZ_VZPS_FILE "/opt/rudder/bin/vzps.py"
      struct stat statbuf;
 +    int i;
  
      /* The file /proc/bc/0 is present on host
         The file /proc/vz is present on guest
-@@ -2354,6 +2356,15 @@ static void OpenVZ_Detect(EvalContext *ctx)
+-       If the host has /bin/vzps, we should use it for checking processes
++       If the host has /opt/rudder/bin/vzps.py, we should use it for checking processes
+     */
+ 
+     if (stat(OPENVZ_HOST_FILENAME, &statbuf) != -1)
+     {
+         Log(LOG_LEVEL_VERBOSE, "This appears to be an OpenVZ/Virtuozzo/Parallels Cloud Server host system.\n");
+         EvalContextClassPutHard(ctx, "virt_host_vz", "inventory,attribute_name=Virtual host,source=agent");
+-        /* if the file /bin/vzps is there, it is safe to use the processes promise type */ 
++        /* if the file /opt/rudder/bin/vzps.py is there, it is safe to use the processes promise type */ 
          if (stat(OPENVZ_VZPS_FILE, &statbuf) != -1)
          {
              EvalContextClassPutHard(ctx, "virt_host_vz_vzps", "inventory,attribute_name=Virtual host,source=agent");
@@ -47,11 +57,10 @@ index b91ca1f..7c897eb 100644
          }
          else
          {
-diff --git a/libpromises/cf3.extern.h b/libpromises/cf3.extern.h
-index 4eb8fc7..27e1d7d 100644
---- a/libpromises/cf3.extern.h
-+++ b/libpromises/cf3.extern.h
-@@ -48,6 +48,7 @@ extern char VPREFIX[];
+diff -r -auN cfengine-3.6.0/libpromises/cf3.extern.h cfengine-3.6.0-patch1/libpromises/cf3.extern.h
+--- cfengine-3.6.0/libpromises/cf3.extern.h	2014-04-01 16:41:01.000000000 +0200
++++ cfengine-3.6.0-patch1/libpromises/cf3.extern.h	2014-09-03 14:49:50.964464893 +0200
+@@ -47,6 +47,7 @@
  
  extern char VDOMAIN[CF_MAXVARSIZE];
  extern PlatformContext VSYSTEMHARDCLASS;
@@ -59,20 +68,39 @@ index 4eb8fc7..27e1d7d 100644
  extern char VFQNAME[];
  extern char VUQNAME[];
  
-diff --git a/libpromises/cf3globals.c b/libpromises/cf3globals.c
-index 71de509..3a3da9b 100644
---- a/libpromises/cf3globals.c
-+++ b/libpromises/cf3globals.c
-@@ -168,3 +168,4 @@ bool MINUSF = false; /* GLOBAL_A */
+diff -r -auN cfengine-3.6.0/libpromises/cf3globals.c cfengine-3.6.0-patch1/libpromises/cf3globals.c
+--- cfengine-3.6.0/libpromises/cf3globals.c	2014-04-01 16:41:01.000000000 +0200
++++ cfengine-3.6.0-patch1/libpromises/cf3globals.c	2014-09-03 14:49:50.964464893 +0200
+@@ -161,3 +161,4 @@
     call external utility
  */
  PlatformContext VSYSTEMHARDCLASS; /* GLOBAL_E?, initialized_later */
 +PlatformContext VPSHARDCLASS; /* used to define which ps command to use*/
-diff --git a/libpromises/processes_select.c b/libpromises/processes_select.c
-index ac5b044..285977e 100644
---- a/libpromises/processes_select.c
-+++ b/libpromises/processes_select.c
-@@ -683,7 +683,7 @@ static const char *GetProcessOptions(void)
+diff -r -auN cfengine-3.6.0/libpromises/classes.c cfengine-3.6.0-patch1/libpromises/classes.c
+--- cfengine-3.6.0/libpromises/classes.c	2014-06-11 16:13:56.000000000 +0200
++++ cfengine-3.6.0-patch1/libpromises/classes.c	2014-09-03 14:54:10.346708558 +0200
+@@ -50,7 +50,7 @@
+ const char *const VPSCOMM[] =
+ {
+     [PLATFORM_CONTEXT_UNKNOWN] = "",
+-    [PLATFORM_CONTEXT_OPENVZ] = "/bin/vzps",                /* virt_host_vz_vzps */
++    [PLATFORM_CONTEXT_OPENVZ] = "/opt/rudder/bin/vzps.py",                /* virt_host_vz_vzps */
+     [PLATFORM_CONTEXT_HP] = "/bin/ps",                  /* hpux */
+     [PLATFORM_CONTEXT_AIX] = "/bin/ps",                  /* aix */
+     [PLATFORM_CONTEXT_LINUX] = "/bin/ps",                  /* linux */
+@@ -76,7 +76,7 @@
+ const char *const VPSOPTS[] =
+ {
+     [PLATFORM_CONTEXT_UNKNOWN] = "",
+-    [PLATFORM_CONTEXT_OPENVZ] = "-E 0 -o user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* virt_host_vz_vzps (with vzps, the -E 0 replace the -e) */
++    [PLATFORM_CONTEXT_OPENVZ] = "-E 0 -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* virt_host_vz_vzps */
+     [PLATFORM_CONTEXT_HP] = "-ef",                      /* hpux */
+     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args", /* aix */
+     [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* linux */
+diff -r -auN cfengine-3.6.0/libpromises/processes_select.c cfengine-3.6.0-patch1/libpromises/processes_select.c
+--- cfengine-3.6.0/libpromises/processes_select.c	2014-06-03 14:39:00.000000000 +0200
++++ cfengine-3.6.0-patch1/libpromises/processes_select.c	2014-09-03 14:49:50.964464893 +0200
+@@ -690,7 +690,7 @@
  
      if (IsGlobalZone())
      {
@@ -81,7 +109,7 @@ index ac5b044..285977e 100644
          return psopts;
      }
  
-@@ -696,7 +696,7 @@ static const char *GetProcessOptions(void)
+@@ -703,7 +703,7 @@
  
  # endif
  
@@ -90,7 +118,7 @@ index ac5b044..285977e 100644
  }
  #endif
  
-@@ -761,7 +761,7 @@ int LoadProcessTable(Item **procdata)
+@@ -768,7 +768,7 @@
  
      const char *psopts = GetProcessOptions();
  
@@ -98,12 +126,11 @@ index ac5b044..285977e 100644
 +    snprintf(pscomm, CF_MAXLINKSIZE, "%s %s", VPSCOMM[VPSHARDCLASS], psopts);
  
      Log(LOG_LEVEL_VERBOSE, "Observe process table with %s", pscomm);
-
-diff --git a/tests/unit/mon_processes_test.c b/tests/unit/mon_processes_test.c
-index 0a096a4..4842ad8 100644
---- a/tests/unit/mon_processes_test.c
-+++ b/tests/unit/mon_processes_test.c
-@@ -109,10 +109,13 @@ int main()
+ 
+diff -r -auN cfengine-3.6.0/tests/unit/mon_processes_test.c cfengine-3.6.0-patch1/tests/unit/mon_processes_test.c
+--- cfengine-3.6.0/tests/unit/mon_processes_test.c	2014-04-01 16:41:01.000000000 +0200
++++ cfengine-3.6.0-patch1/tests/unit/mon_processes_test.c	2014-09-03 14:49:50.964464893 +0200
+@@ -104,10 +104,13 @@
  
  #if defined(__sun)
      VSYSTEMHARDCLASS = PLATFORM_CONTEXT_SOLARIS;
@@ -116,4 +143,4 @@ index 0a096a4..4842ad8 100644
 +    VPSHARDCLASS = PLATFORM_CONTEXT_LINUX;
  #endif
  
-     PRINT_TEST_BANNER(); 
+     PRINT_TEST_BANNER();


### PR DESCRIPTION
Be careful, this is a diff on a patch file.

The new patch does what it did before, plus it replaces  /bin/vzps with /opt/rudder/bin/vzps.py and adds a -e option to it.
