### PR TITLE
Fixes #4644: Cannot upgrade from 2.9.2 to 2.9.4 due to an error on '/etc...

### DIFF
--- a/rudder-server-root/debian/postinst
+++ b/rudder-server-root/debian/postinst
@@ -34,6 +34,8 @@ case "$1" in
 		fi
 
 		if dpkg-maintscript-helper supports mv_conffile 2>/dev/null; then
+			# dpkg-maintscript-helper mv_conffile appears to be dumb enough to try and mv the new file even if it doesn't exist...
+			[ -e /etc/logrotate.d/rudder ] || touch /etc/logrotate.d/rudder
 			dpkg-maintscript-helper mv_conffile /etc/logrotate.d/rudder-server-root /etc/logrotate.d/rudder -- "$@"
 		fi
     ;;


### PR DESCRIPTION
.../logrotate.d/rudder'

This replaces #461, which was on an old branch.
