### PR TITLE
Fixes #5503 : correct evaluation of promises by cfengine, to be able to delete file based on date

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -45,6 +45,7 @@ localdepends: ./initial-promises ./detect_os.sh ./files ./fusioninventory-agent 
 	$(PATCH) -d ./cfengine-source -p1 < ./patches/cfengine/0005-fix-readstringarrayidx-duplicate-lines.patch
 	$(PATCH) -d ./cfengine-source -p1 < ./patches/cfengine/0006-openvz-support.patch
 	$(PATCH) -d ./cfengine-source -p1 < ./patches/cfengine/0007-no-runlog.patch
+	$(PATCH) -d ./cfengine-source -p1 < ./patches/cfengine/0008-fix-promise-evaluation.patch
 	# Bootstrap the package using autogen before compilation
 	cd cfengine-source && NO_CONFIGURE=1 ./autogen.sh
 

--- a/rudder-agent/SOURCES/patches/cfengine/0008-fix-promise-evaluation.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/0008-fix-promise-evaluation.patch
@@ -1,0 +1,31 @@
+From 77caac16aab82cb8b6239d59cf5e5eae8bb7e853 Mon Sep 17 00:00:00 2001
+From: Volker Hilsheimer <volker.hilsheimer@cfengine.com>
+Date: Thu, 25 Sep 2014 13:56:48 +0200
+Subject: [PATCH] Evaluate functions also for ifvarclass'ed promises
+
+This takes in a small modification from
+3054d112a4b537c63a248dc59b6aa66f53d9f6dc and reverts parts of
+the logic introduced in f0f4743f4071c9f605da13bee9ea4f195b826ca3.
+
+In master, we no longer skip function evaluations here at all -
+the promise skipping should be done earlier.
+---
+ libpromises/fncall.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/libpromises/fncall.c b/libpromises/fncall.c
+index 6053017..d3cca4b 100644
+--- a/libpromises/fncall.c
++++ b/libpromises/fncall.c
+@@ -289,11 +289,6 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp,
+             fp->name);
+         return (FnCallResult) { FNCALL_FAILURE, { FnCallCopy(fp), RVAL_TYPE_FNCALL } };
+     }
+-    else if (caller && !EvalContextPromiseIsActive(ctx, caller))
+-    {
+-        Log(LOG_LEVEL_VERBOSE, "Skipping function '%s', because it was excluded by classes", fp->name);
+-        return (FnCallResult) { FNCALL_FAILURE, { FnCallCopy(fp), RVAL_TYPE_FNCALL } };
+-    }
+ 
+     const FnCallType *fp_type = FnCallTypeGet(fp->name);
+ 


### PR DESCRIPTION
Based on https://github.com/vohi/core/commit/77caac16aab82cb8b6239d59cf5e5eae8bb7e853#diff-823bcdb0d3f3367a25567abbe6c3d973R288.patch , see also https://dev.cfengine.com/issues/6577
Related bug are 
- http://www.rudder-project.org/redmine/issues/5503
- http://www.rudder-project.org/redmine/issues/5565 
