### PR TITLE
Fixes #4650: don't duplicate headers with Rudder agent

### DIFF
--- a/rudder-agent/SOURCES/0005-dont-duplicate-text-blocks.patch
+++ b/rudder-agent/SOURCES/0005-dont-duplicate-text-blocks.patch
@@ -1,0 +1,126 @@
+From a0ede551aa76ada65fd8001fe0e061479283fb76 Mon Sep 17 00:00:00 2001
+From: Nicolas CHARLES <nicolas.charles@normation.com>
+Date: Thu, 9 Oct 2014 16:33:22 +0200
+Subject: [PATCH 1/2] Backporting commit
+ df2c2aee833f41e175605d8c5824d7e7375c0d85 from Mark Burgess into 3.5.3
+
+---
+ cf-agent/files_editline.c | 14 +++++++-------
+ libpromises/mod_files.c   |  2 +-
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/cf-agent/files_editline.c b/cf-agent/files_editline.c
+index 7900a22..3ae750a 100644
+--- a/cf-agent/files_editline.c
++++ b/cf-agent/files_editline.c
+@@ -260,7 +260,7 @@ Bundle *MakeTemporaryBundleFromTemplate(EvalContext *ctx, Policy *policy, Attrib
+                 *(sp-1) = '\0'; // StripTrailingNewline(promiser) and terminate
+ 
+                 np = PromiseTypeAppendPromise(tp, promiser, (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, context);
+-                PromiseAppendConstraint(np, "insert_type", (Rval) { xstrdup("preserve_block"), RVAL_TYPE_SCALAR }, "any", false);
++                PromiseAppendConstraint(np, "insert_type", (Rval) { xstrdup("preserve_all_lines"), RVAL_TYPE_SCALAR }, "any", false);
+ 
+                 DeleteItemList(lines);
+                 free(promiser);
+@@ -283,7 +283,7 @@ Bundle *MakeTemporaryBundleFromTemplate(EvalContext *ctx, Policy *policy, Attrib
+                         Log(LOG_LEVEL_ERR, "StripTrailingNewline was called on an overlong string");
+                     }
+                     np = PromiseTypeAppendPromise(tp, buffer, (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, context);
+-                    PromiseAppendConstraint(np, "insert_type", (Rval) { xstrdup("preserve_block"), RVAL_TYPE_SCALAR }, "any", false);
++                    PromiseAppendConstraint(np, "insert_type", (Rval) { xstrdup("preserve_all_lines"), RVAL_TYPE_SCALAR }, "any", false);
+                 }
+             }
+         }
+@@ -570,7 +570,7 @@ static void VerifyLineInsertions(EvalContext *ctx, Promise *pp, EditContext *edc
+     char lockname[CF_BUFSIZE];
+ 
+     Attributes a = GetInsertionAttributes(ctx, pp);
+-    int preserve_block = a.sourcetype && strcmp(a.sourcetype, "preserve_block") == 0;
++    int allow_multi_lines = a.sourcetype && strcmp(a.sourcetype, "preserve_all_lines") == 0;
+     a.transaction.ifelapsed = CF_EDIT_IFELAPSED;
+ 
+     if (!SanityCheckInsertions(a))
+@@ -596,7 +596,7 @@ static void VerifyLineInsertions(EvalContext *ctx, Promise *pp, EditContext *edc
+     }
+ 
+ 
+-    if (preserve_block)
++    if (allow_multi_lines)
+     {
+         // promise to insert duplicates on first pass only
+         snprintf(lockname, CF_BUFSIZE - 1, "insertline-%s-%s-%lu", pp->promiser, edcontext->filename, (long unsigned int) pp->org_pp);
+@@ -718,7 +718,7 @@ If no such region matches, begin_ptr and end_ptr should point to CF_UNDEFINED_IT
+ static int InsertMultipleLinesToRegion(EvalContext *ctx, Item **start, Item *begin_ptr, Item *end_ptr, Attributes a, Promise *pp, EditContext *edcontext)
+ {
+     Item *ip, *prev = CF_UNDEFINED_ITEM;
+-    int preserve_block = a.sourcetype && strcmp(a.sourcetype, "preserve_block") == 0;
++    int allow_multi_lines = a.sourcetype && strcmp(a.sourcetype, "preserve_all_lines") == 0;
+ 
+     // Insert at the start of the file
+     
+@@ -748,7 +748,7 @@ static int InsertMultipleLinesToRegion(EvalContext *ctx, Item **start, Item *beg
+     {
+         for (ip = *start; ip != NULL; ip = ip->next)
+         {
+-            if (!preserve_block && MatchRegion(pp->promiser, ip, end_ptr, true))
++            if (!allow_multi_lines && MatchRegion(pp->promiser, ip, end_ptr, true))
+             {
+                 cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a, "Promised chunk '%s' exists within selected region of %s (promise kept)", pp->promiser, edcontext->filename);
+                 return false;
+@@ -1340,7 +1340,7 @@ static int InsertCompoundLineAtLocation(EvalContext *ctx, char *chunk, Item **st
+     int result = false;
+     char buf[CF_EXPANDSIZE];
+     char *sp;
+-    int preserve_block = a.sourcetype && (strcmp(a.sourcetype, "preserve_block") == 0 || strcmp(a.sourcetype, "file_preserve_block") == 0);
++    int preserve_block = a.sourcetype && (strcmp(a.sourcetype, "preserve_all_lines") == 0 || strcmp(a.sourcetype, "preserve_block") == 0 || strcmp(a.sourcetype, "file_preserve_block") == 0);
+ 
+     if (!preserve_block && MatchRegion(chunk, location, NULL, false))
+     {
+diff --git a/libpromises/mod_files.c b/libpromises/mod_files.c
+index c2fab03..e9d5434 100644
+--- a/libpromises/mod_files.c
++++ b/libpromises/mod_files.c
+@@ -101,7 +101,7 @@ static const BodySyntax insert_select_body = BodySyntaxNew("insert_select", inse
+ static const ConstraintSyntax CF_INSERTLINES_BODIES[] =
+ {
+     ConstraintSyntaxNewBool("expand_scalars", "Expand any unexpanded variables. Default value: false", SYNTAX_STATUS_NORMAL),
+-    ConstraintSyntaxNewOption("insert_type", "literal,string,file,file_preserve_block,preserve_block", "Type of object the promiser string refers to. Default value: literal", SYNTAX_STATUS_NORMAL),
++    ConstraintSyntaxNewOption("insert_type", "literal,string,file,file_preserve_block,preserve_block,preserve_all_lines", "Type of object the promiser string refers to. Default value: literal", SYNTAX_STATUS_NORMAL),
+     ConstraintSyntaxNewBody("insert_select", &insert_select_body, "Insert only if lines pass filter criteria", SYNTAX_STATUS_NORMAL),
+     ConstraintSyntaxNewBody("location", &location_body, "Specify where in a file an insertion will be made", SYNTAX_STATUS_NORMAL),
+     ConstraintSyntaxNewOptionList("whitespace_policy", "ignore_leading,ignore_trailing,ignore_embedded,exact_match", "Criteria for matching and recognizing existing lines", SYNTAX_STATUS_NORMAL),
+-- 
+2.1.0
+
+
+From b76235892a91177b19ec56f10a9dd98cff90eaff Mon Sep 17 00:00:00 2001
+From: Nicolas CHARLES <nicolas.charles@normation.com>
+Date: Thu, 9 Oct 2014 16:39:55 +0200
+Subject: [PATCH 2/2] Backporting commit
+ 37065c7ac536a8147179eeb091d985abe62d887e from Volker Hilsheimer into CFEngine
+ 3.5.3
+
+---
+ cf-agent/files_editline.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/cf-agent/files_editline.c b/cf-agent/files_editline.c
+index 3ae750a..8a7843b 100644
+--- a/cf-agent/files_editline.c
++++ b/cf-agent/files_editline.c
+@@ -1340,9 +1340,10 @@ static int InsertCompoundLineAtLocation(EvalContext *ctx, char *chunk, Item **st
+     int result = false;
+     char buf[CF_EXPANDSIZE];
+     char *sp;
+-    int preserve_block = a.sourcetype && (strcmp(a.sourcetype, "preserve_all_lines") == 0 || strcmp(a.sourcetype, "preserve_block") == 0 || strcmp(a.sourcetype, "file_preserve_block") == 0);
++    int preserve_all_lines = a.sourcetype && strcmp(a.sourcetype, "preserve_all_lines") == 0;
++    int preserve_block = a.sourcetype && (preserve_all_lines || strcmp(a.sourcetype, "preserve_block") == 0 || strcmp(a.sourcetype, "file_preserve_block") == 0);
+ 
+-    if (!preserve_block && MatchRegion(chunk, location, NULL, false))
++    if (!preserve_all_lines && MatchRegion(chunk, location, NULL, false))
+     {
+         cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a, "Promised chunk '%s' exists within selected region of %s (promise kept)", pp->promiser, edcontext->filename);
+         return false;
+-- 
+2.1.0
+

--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -43,6 +43,7 @@ localdepends: ./initial-promises ./detect_os.sh ./files ./fusioninventory-agent 
 	$(PATCH) -d ./cfengine-source -p1 < ./0002-Fix-failure-to-open-paths-ending-in-a-slash.patch
 	$(PATCH) -d ./cfengine-source -p1 < ./0003-Fix-incorrect-return-value-for-empty-string-in-safe_.patch
 	$(PATCH) -d ./cfengine-source -p1 < ./0004-Make-safe_open-treat-trailing-slashes-like-open.patch
+	$(PATCH) -d ./cfengine-source -p1 < ./0005-dont-duplicate-text-blocks.patch
 
 ./tokyocabinet-source: /usr/bin/wget
 	# Original URL: http://fallabs.com/tokyocabinet/tokyocabinet-${TOKYOCABINET_RELEASE}.tar.gz


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/4650

To be merged in 2.10
