### PR TITLE
Fixes #5651: Use the same SPEC macro version comparison everywhere

### DIFF
--- a/rudder-agent-thin/SOURCES/patches/rudder-agent-thin/0002-rudder-agent-to-rudder-agent-thin-spec.patch
+++ b/rudder-agent-thin/SOURCES/patches/rudder-agent-thin/0002-rudder-agent-to-rudder-agent-thin-spec.patch
@@ -35,7 +35,7 @@ diff -Naur a/rudder-agent.spec b/rudder-agent.spec
 -AutoReq: 0
 -AutoProv: 0
 -
- %if 0%{?rhel} == 4
+ %if 0%{?rhel} && 0%{?rhel} == 4
  Patch1: fix-missing-headers
  %endif
 @@ -85,9 +79,9 @@

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -77,7 +77,7 @@ Source100: uuidgen
 AutoReq: 0
 AutoProv: 0
 
-%if 0%{?rhel} == 4
+%if 0%{?rhel} && 0%{?rhel} == 4
 Patch1: fix-missing-headers
 %endif
 
@@ -172,7 +172,7 @@ FusionInventory.
 # Source preparation
 #=================================================
 %prep
-%if 0%{?rhel} == 4
+%if 0%{?rhel} && 0%{?rhel} == 4
 %patch1 -p1
 %endif
 
@@ -372,7 +372,7 @@ then
 %else
 	chkconfig --add rudder-agent
 %endif
-	%if 0%{?rhel} >= 6
+	%if 0%{?rhel} && 0%{?rhel} >= 6
 	chkconfig rudder-agent on
 	%endif
 

--- a/rudder-inventory-endpoint/SPECS/rudder-inventory-endpoint.spec
+++ b/rudder-inventory-endpoint/SPECS/rudder-inventory-endpoint.spec
@@ -36,13 +36,15 @@
 
 %define maven_settings settings-external.xml
 
-%if 0%{?sles_version} 
+%if 0%{?sles_version}
 %define syslogservicename syslog
 %endif
-%if 0%{?el5} 
+
+%if 0%{?rhel} == 5 || 0%{?el5}
 %define syslogservicename syslog
 %endif
-%if 0%{?el6} 
+
+%if 0%{?rhel} && 0%{?rhel} > 5
 %define syslogservicename rsyslog
 %endif
 

--- a/rudder-inventory-ldap/SPECS/rudder-inventory-ldap.spec
+++ b/rudder-inventory-ldap/SPECS/rudder-inventory-ldap.spec
@@ -40,11 +40,11 @@
 %define syslogservicename syslog
 %endif
 
-%if 0%{?el5} 
+%if 0%{?rhel} == 5 || 0%{?el5}
 %define syslogservicename syslog
 %endif
 
-%if 0%{?el6} 
+%if 0%{?rhel} && 0%{?rhel} > 5
 %define syslogservicename rsyslog
 %endif
 
@@ -79,22 +79,22 @@ Requires: rsyslog cyrus-sasl openssl
 
 #Specific requirements
 
-%if 0%{?sles_version} == 10
+%if 0%{?sles_version} && 0%{?sles_version} == 10
 BuildRequires: db42-devel openssl-devel
 Requires: db42
 %endif
 
-%if 0%{?sles_version} == 11
+%if 0%{?sles_version} && 0%{?sles_version} == 11
 BuildRequires: libdb-4_5-devel libopenssl-devel
 Requires: libdb-4_5
 %endif
 
-%if 0%{?rhel} < 7
+%if 0%{?rhel} && 0%{?rhel} < 7
 BuildRequires: db4-devel openssl-devel libtool-ltdl-devel
 Requires: db4
 %endif
 
-%if 0%{?rhel} >= 7
+%if 0%{?rhel} && 0%{?rhel} >= 7
 BuildRequires: libdb-devel openssl-devel libtool-ltdl-devel
 Requires: libdb
 %endif
@@ -195,7 +195,8 @@ fi
 
 echo -n "INFO: Setting rudder-slapd as a boot service..."
 chkconfig --add rudder-slapd >/dev/null 2>&1
-%if 0%{?rhel} >= 6
+
+%if 0%{?rhel} && 0%{?rhel} >= 6
 chkconfig rudder-slapd on
 %endif
 echo " Done"

--- a/rudder-jetty/SPECS/rudder-jetty.spec
+++ b/rudder-jetty/SPECS/rudder-jetty.spec
@@ -75,11 +75,11 @@ BuildArch: noarch
 # Also, I would like to have something like %elif here, but not implemented
 # in RPM yet...
 
-%if 0%{?rhel} > 6
+%if 0%{?rhel} && 0%{?rhel} > 6
 Requires: jre >= 1.7
 %endif
 
-%if 0%{?rhel} == 6
+%if 0%{?rhel} && 0%{?rhel} == 6
 Requires: java-1.7.0-openjdk
 %endif
 
@@ -172,7 +172,7 @@ if [ $1 -eq 1 ]
 then
 	# Set rudder-agent as service
 	chkconfig --add rudder-jetty
-	%if 0%{?rhel} >= 6
+	%if 0%{?rhel} && 0%{?rhel} >= 6
 	chkconfig rudder-jetty on
 	%endif
 fi

--- a/rudder-reports/SPECS/rudder-reports.spec
+++ b/rudder-reports/SPECS/rudder-reports.spec
@@ -58,15 +58,15 @@ BuildArch: noarch
 Requires: postgresql-server >= 8
 Requires: rsyslog >= 4
 
-%if 0%{?sles_version} == 10
+%if 0%{?sles_version} && 0%{?sles_version} == 10
 Requires: %{suse_rsyslogpsl} >= 4
 %endif
 
-%if 0%{?sles_version} == 11
+%if 0%{?sles_version} && 0%{?sles_version} == 11
 Requires: %{suse_rsyslogpsl} >= 4
 %endif
 
-%if 0%{?el6}
+%if 0%{?rhel} && 0%{?rhel} >= 6
 Requires: rsyslog-pgsql >= 4
 %endif
 
@@ -114,7 +114,7 @@ service postgresql status > /dev/null
 
 if [ $? -ne 0 ]
 then
-%if 0%{?el6}
+%if 0%{?rhel} && 0%{?rhel} >= 6
   service postgresql initdb
 %endif
   service postgresql start
@@ -145,7 +145,7 @@ fi
 
 echo -n "INFO: Setting postgresql as a boot service..."
 chkconfig --add postgresql >/dev/null 2>&1
-%if 0%{?rhel} >= 6
+%if 0%{?rhel} && 0%{?rhel} >= 6
 chkconfig postgresql on >/dev/null 2>&1
 %endif
 echo " Done"

--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -48,7 +48,7 @@
 %define ldap_clients            openldap2-client
 %define usermod_opt             A
 %endif
-%if 0%{?el5}
+%if 0%{?rhel} == 5 || 0%{?el5}
 %define apache                  httpd
 %define apache_tools            httpd-tools
 %define apache_group            apache
@@ -58,7 +58,7 @@
 %define ldap_clients            openldap-clients
 %define usermod_opt             aG
 %endif
-%if 0%{?rhel} >= 6
+%if 0%{?rhel} && 0%{?rhel} >= 6
 %define apache                  httpd
 %define apache_tools            httpd-tools
 %define apache_group            apache
@@ -264,7 +264,7 @@ echo 'root' > /opt/rudder/etc/uuid.hive
 
 echo -n "INFO: Setting Apache HTTPd as a boot service..."
 chkconfig --add %{apache} 2&> /dev/null
-%if 0%{?rhel} >= 6
+%if 0%{?rhel} && 0%{?rhel} >= 6
 chkconfig %{apache} on
 %endif
 echo " Done"


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5651

To be merged in master

This commit uses the same way of comparing OS versions everywhere, to prevent "less than / less of equal than" comparisons from breaking due to macro expansion to 0 if the macro is not defined.

0%{?rhel} <= 4 becomes %if 0%{?rhel} && 0%{?rhel} <= 4 (making the expansion to 0 harmless as the first condition is also 0, meaning false in the case of a "if"
