### PR TITLE
Fixes #5782: Use the JDK 1.7+ by default on our packages

### DIFF
--- a/rudder-inventory-endpoint/SOURCES/.dependencies
+++ b/rudder-inventory-endpoint/SOURCES/.dependencies
@@ -1,1 +1,5 @@
+RHEL6:java7-devel
+RHEL7:java-devel
+FEDORA18:java-devel
+FEDORA20:java-devel
 JAVA:jdk

--- a/rudder-inventory-endpoint/SOURCES/Makefile
+++ b/rudder-inventory-endpoint/SOURCES/Makefile
@@ -23,7 +23,7 @@ WGET := $(if $(PROXY), http_proxy=$(PROXY) ftp_proxy=$(PROXY)) /usr/bin/wget -q
 
 RUDDER_VERSION_TO_PACKAGE = <put Rudder version or version-snapshot here>
 
-localdepends: ./rudder-sources ./inventory-web.properties ./maven2/bin/mvn
+localdepends: ./rudder-sources ./inventory-web.properties ./maven/bin/mvn
 
 /usr/bin/wget:
 	sudo aptitude --assume-yes install wget
@@ -32,10 +32,10 @@ localdepends: ./rudder-sources ./inventory-web.properties ./maven2/bin/mvn
 	# Original URL: http://apache.multidist.com/maven/binaries/apache-maven-$(MAVEN_RELEASE)-bin.tar.gz
 	$(WGET) -O ./maven.tgz http://www.normation.com/tarball/apache-maven-$(MAVEN_RELEASE)-bin.tar.gz
 
-./maven2/bin/mvn: ./maven.tgz
+./maven/bin/mvn: ./maven.tgz
 	tar -xzf ./maven.tgz -C .
-	rm -rf ./maven2
-	mv ./apache-maven-$(MAVEN_RELEASE) ./maven2
+	rm -rf ./maven
+	mv ./apache-maven-$(MAVEN_RELEASE) ./maven
 
 ./rudder-sources.tar.bz2:
 	$(WGET) -O rudder-sources.tar.bz2 http://www.rudder-project.org/archives/rudder-sources-${RUDDER_VERSION_TO_PACKAGE}.tar.bz2
@@ -48,7 +48,7 @@ localdepends: ./rudder-sources ./inventory-web.properties ./maven2/bin/mvn
 	cp ./rudder-sources/ldap-inventory/inventory-provisioning-web/src/main/resources/configuration.properties.sample ./inventory-web.properties
 
 localclean:
-	rm -rf ./maven2
+	rm -rf ./maven
 	rm -rf ./inventory-web.properties
 	rm -rf ./rudder-sources
 

--- a/rudder-inventory-endpoint/SPECS/rudder-inventory-endpoint.spec
+++ b/rudder-inventory-endpoint/SPECS/rudder-inventory-endpoint.spec
@@ -69,20 +69,40 @@ Source4: endpoint.xml
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
 
-BuildRequires: jdk >= 1.6
+# Dependencies
+
 Requires: rudder-inventory-ldap
 
-# Those are virtual packages provided by our Jetty package and the system one.
+# OS-specific dependencies
+
+##
+## Those jetty packages are virtual packages provided by our Jetty and the system one.
+##
+
+## 1 - RHEL
+%if 0%{?rhel} && 0%{?rhel} == 6
+BuildRequires: java7-devel
+%endif
+
+%if 0%{?rhel} && 0%{?rhel} >= 7
+BuildRequires: java-devel
+%endif
+
 %if 0%{?rhel}
 Requires: jetty-eclipse
 %endif
 
+## 2 - Fedora
 %if 0%{?fedora}
+# Cf. https://fedoraproject.org/wiki/Packaging:Java for details
+BuildRequires: java-devel
 Requires: jetty-server
 %endif
 
-# No Jetty provided by SLES... Use our own.
+## 3 - SLES
+## No Jetty provided by SLES... Use our own.
 %if 0%{?sles_version}
+BuildRequires: jdk >= 1.7
 Requires: rudder-jetty
 %endif
 
@@ -109,11 +129,11 @@ cp -rf %{_sourcedir}/rudder-sources %{_builddir}
 %build
 
 export MAVEN_OPTS=-Xmx512m
-cd %{_builddir}/rudder-sources/rudder-parent-pom && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
-cd %{_builddir}/rudder-sources/rudder-commons && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
-cd %{_builddir}/rudder-sources/scala-ldap && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
-cd %{_builddir}/rudder-sources/ldap-inventory && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
-cd %{_builddir}/rudder-sources/ldap-inventory/inventory-provisioning-web && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install package
+cd %{_builddir}/rudder-sources/rudder-parent-pom && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
+cd %{_builddir}/rudder-sources/rudder-commons && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
+cd %{_builddir}/rudder-sources/scala-ldap && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
+cd %{_builddir}/rudder-sources/ldap-inventory && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
+cd %{_builddir}/rudder-sources/ldap-inventory/inventory-provisioning-web && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install package
 
 # Installation
 #=================================================

--- a/rudder-inventory-endpoint/debian/control
+++ b/rudder-inventory-endpoint/debian/control
@@ -2,7 +2,7 @@ Source: rudder-inventory-endpoint
 Section: web
 Priority: extra
 Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
-Build-Depends: debhelper (>= 7), sun-java6-jdk | java7-jdk
+Build-Depends: debhelper (>= 7), openjdk-7-jdk | openjdk-8-jdk
 Standards-Version: 3.8.0
 Homepage: http://www.rudder-project.org
 

--- a/rudder-inventory-endpoint/debian/rules
+++ b/rudder-inventory-endpoint/debian/rules
@@ -9,10 +9,6 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-# Set JAVA_HOME according to available JVM
-# We support Sun Java 6 or OpenJDK 7, privilege later versions (sort -r)
-export JAVA_HOME := $(shell find /usr/lib/jvm -maxdepth 1 -type d -name java-7-openjdk-i386 -or -name java-7-openjdk-amd64 -or -name java-6-sun | sort -r | head -n1)
-
 export MAVEN_OPTS := -Xmx512m
 MAVEN_SETTINGS := settings-external.xml
 
@@ -27,11 +23,11 @@ build-stamp: configure-stamp
 	dh_testdir
 
 	ls -lh $(CURDIR)/SOURCES/rudder-sources
-	cd $(CURDIR)/SOURCES/rudder-sources/rudder-parent-pom && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
-	cd $(CURDIR)/SOURCES/rudder-sources/rudder-commons && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
-	cd $(CURDIR)/SOURCES/rudder-sources/scala-ldap && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
-	cd $(CURDIR)/SOURCES/rudder-sources/ldap-inventory && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
-	cd $(CURDIR)/SOURCES/rudder-sources/ldap-inventory/inventory-provisioning-web && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install package
+	cd $(CURDIR)/SOURCES/rudder-sources/rudder-parent-pom && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
+	cd $(CURDIR)/SOURCES/rudder-sources/rudder-commons && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
+	cd $(CURDIR)/SOURCES/rudder-sources/scala-ldap && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
+	cd $(CURDIR)/SOURCES/rudder-sources/ldap-inventory && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
+	cd $(CURDIR)/SOURCES/rudder-sources/ldap-inventory/inventory-provisioning-web && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install package
 
 	touch $@
 

--- a/rudder-webapp/SOURCES/.dependencies
+++ b/rudder-webapp/SOURCES/.dependencies
@@ -1,1 +1,5 @@
+RHEL6:java7-devel
+RHEL7:java-devel
+FEDORA18:java-devel
+FEDORA20:java-devel
 JAVA:jdk

--- a/rudder-webapp/SOURCES/Makefile
+++ b/rudder-webapp/SOURCES/Makefile
@@ -24,7 +24,7 @@ WGET := $(if $(PROXY), http_proxy=$(PROXY) ftp_proxy=$(PROXY)) /usr/bin/wget -q
 RUDDER_VERSION_TO_PACKAGE = <put Rudder version or version-snapshot here>
 RUDDER_MAJOR_VERSION := $(shell echo ${RUDDER_VERSION_TO_PACKAGE} | cut -d'.' -f 1-2)
 
-localdepends: ./rudder-sources ./maven2/bin/mvn ./rudder-users.xml ./rudder-doc ./rudder-doc/html/rudder-doc.pdf
+localdepends: ./rudder-sources ./maven/bin/mvn ./rudder-users.xml ./rudder-doc ./rudder-doc/html/rudder-doc.pdf
 
 /usr/bin/wget:
 	sudo aptitude --assume-yes install wget
@@ -33,10 +33,10 @@ localdepends: ./rudder-sources ./maven2/bin/mvn ./rudder-users.xml ./rudder-doc 
 	# Original URL: http://apache.multidist.com/maven/binaries/apache-maven-$(MAVEN_RELEASE)-bin.tar.gz
 	$(WGET) -O ./maven.tgz http://www.normation.com/tarball/apache-maven-$(MAVEN_RELEASE)-bin.tar.gz
 
-./maven2/bin/mvn: ./maven.tgz
+./maven/bin/mvn: ./maven.tgz
 	tar -xzf ./maven.tgz -C .
-	rm -rf ./maven2
-	mv ./apache-maven-$(MAVEN_RELEASE) ./maven2
+	rm -rf ./maven
+	mv ./apache-maven-$(MAVEN_RELEASE) ./maven
 
 ./rudder-sources.tar.bz2:
 	$(WGET) -O rudder-sources.tar.bz2 http://www.rudder-project.org/archives/rudder-sources-${RUDDER_VERSION_TO_PACKAGE}.tar.bz2
@@ -60,7 +60,7 @@ localdepends: ./rudder-sources ./maven2/bin/mvn ./rudder-users.xml ./rudder-doc 
 
 localclean:
 	rm -rf ./rudder-users.xml
-	rm -rf ./maven2/
+	rm -rf ./maven/
 	rm -rf ./rudder-sources
 	rm -rf ./rudder-doc
 

--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -101,27 +101,43 @@ Source16: post.write_technique.rudderify.sh
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
 
-BuildRequires: jdk >= 1.6
+# Dependencies
+
 Requires: rudder-techniques ncf ncf-api-virtualenv %{apache} %{apache_tools} git-core rsync openssl %{ldap_clients}
 
-# We need the psql client so that we can run database checks and upgrades (rudder-upgrade, in particular)
+# We need the PostgreSQL client utilities so that we can run database checks and upgrades (rudder-upgrade, in particular)
 Requires: postgresql
 
-# Those jetty packages are virtual packages provided by our Jetty and the system one.
+# OS-specific dependencies
 
-## RHEL
+##
+## Those jetty packages are virtual packages provided by our Jetty and the system one.
+##
+
+## 1 - RHEL
+%if 0%{?rhel} && 0%{?rhel} == 6
+BuildRequires: java7-devel
+%endif
+
+%if 0%{?rhel} && 0%{?rhel} >= 7
+BuildRequires: java-devel
+%endif
+
 %if 0%{?rhel}
 Requires: mod_ssl jetty-eclipse
 %endif
 
-## Fedora
+## 2 - Fedora
 %if 0%{?fedora}
+# Cf. https://fedoraproject.org/wiki/Packaging:Java for details
+BuildRequires: java-devel
 Requires: jetty-server
 %endif
 
-## SLES
+## 3 - SLES
 ## No Jetty provided by SLES... Use our own.
 %if 0%{?sles_version}
+BuildRequires: jdk >= 1.7
 Requires: rudder-jetty
 %endif
 
@@ -131,7 +147,6 @@ Rudder is an open source configuration management and audit solution.
 This package contains the web application that is the main user interface to
 Rudder. The webapp is automatically installed and started using the Jetty
 application server bundled in the rudder-jetty package.
-
 
 #=================================================
 # Source preparation
@@ -147,12 +162,12 @@ cp -rf %{_sourcedir}/rudder-doc %{_builddir}
 %build
 
 export MAVEN_OPTS=-Xmx512m
-cd %{_builddir}/rudder-sources/rudder-parent-pom && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
-cd %{_builddir}/rudder-sources/rudder-commons    && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
-cd %{_builddir}/rudder-sources/scala-ldap        && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
-cd %{_builddir}/rudder-sources/ldap-inventory    && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
-cd %{_builddir}/rudder-sources/cf-clerk          && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
-cd %{_builddir}/rudder-sources/rudder            && %{_sourcedir}/maven2/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install package
+cd %{_builddir}/rudder-sources/rudder-parent-pom && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
+cd %{_builddir}/rudder-sources/rudder-commons    && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
+cd %{_builddir}/rudder-sources/scala-ldap        && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
+cd %{_builddir}/rudder-sources/ldap-inventory    && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
+cd %{_builddir}/rudder-sources/cf-clerk          && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install
+cd %{_builddir}/rudder-sources/rudder            && %{_sourcedir}/maven/bin/mvn -s %{_sourcedir}/%{maven_settings} -Dmaven.test.skip=true install package
 
 #=================================================
 # Installation

--- a/rudder-webapp/debian/control
+++ b/rudder-webapp/debian/control
@@ -2,7 +2,7 @@ Source: rudder-webapp
 Section: web
 Priority: extra
 Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
-Build-Depends: debhelper (>= 7), sun-java6-jdk | java7-jdk
+Build-Depends: debhelper (>= 7), openjdk-7-jdk | openjdk-8-jdk
 Standards-Version: 3.8.0
 Homepage: http://www.rudder-project.org
 

--- a/rudder-webapp/debian/rules
+++ b/rudder-webapp/debian/rules
@@ -9,10 +9,6 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-# Set JAVA_HOME according to available JVM
-# We support Sun Java 6 or OpenJDK 7, privilege later versions (sort -r)
-export JAVA_HOME := $(shell find /usr/lib/jvm -maxdepth 1 -type d -name java-7-openjdk-i386 -or -name java-7-openjdk-amd64 -or -name java-6-sun | sort -r | head -n1)
-
 export MAVEN_OPTS := -Xmx512m
 MAVEN_SETTINGS := settings-external.xml
 
@@ -26,12 +22,12 @@ build: build-stamp
 build-stamp: configure-stamp
 	dh_testdir
 	
-	cd $(CURDIR)/SOURCES/rudder-sources/rudder-parent-pom && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
-	cd $(CURDIR)/SOURCES/rudder-sources/rudder-commons && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
-	cd $(CURDIR)/SOURCES/rudder-sources/scala-ldap && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
-	cd $(CURDIR)/SOURCES/rudder-sources/ldap-inventory && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
-	cd $(CURDIR)/SOURCES/rudder-sources/cf-clerk && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
-	cd $(CURDIR)/SOURCES/rudder-sources/rudder && $(CURDIR)/SOURCES/maven2/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install package
+	cd $(CURDIR)/SOURCES/rudder-sources/rudder-parent-pom && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
+	cd $(CURDIR)/SOURCES/rudder-sources/rudder-commons && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
+	cd $(CURDIR)/SOURCES/rudder-sources/scala-ldap && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
+	cd $(CURDIR)/SOURCES/rudder-sources/ldap-inventory && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
+	cd $(CURDIR)/SOURCES/rudder-sources/cf-clerk && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install
+	cd $(CURDIR)/SOURCES/rudder-sources/rudder && $(CURDIR)/SOURCES/maven/bin/mvn -s $(CURDIR)/SOURCES/$(MAVEN_SETTINGS) -Dmaven.test.skip=true install package
 
 	touch $@
 


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5782

To be merged in 3.0
