### PR TITLE
Fixes #5814: Do not use a SPEC file macro in plain OpenSSL patches

### DIFF
--- a/rudder-agent/SOURCES/patches/DEBIAN_3/0001-use-bundled-openssl.patch
+++ b/rudder-agent/SOURCES/patches/DEBIAN_3/0001-use-bundled-openssl.patch
@@ -19,7 +19,7 @@ diff -Naur debian/rules debian/rules
  	cd SOURCES && ./perl-prepare.sh $(CURDIR)/SOURCES/fusioninventory-agent
 +	# Compile and install OpenSSL
 +	cd SOURCES/openssl-source && ./config -fPIC --prefix=/opt/rudder --openssldir=/opt/rudder/openssl shared
-+	cd SOURCES/openssl-source && make %{?_smp_mflags}
++	cd SOURCES/openssl-source && make
 +	cd SOURCES/openssl-source && make install INSTALL_PREFIX=$(CURDIR)/debian/tmp
  	# Compile the LMDB library and install it in /opt/rudder
  	# LMDB source code does not know how to create destination folders, do it ourselves

--- a/rudder-agent/SOURCES/patches/DEBIAN_4/0001-use-bundled-openssl.patch
+++ b/rudder-agent/SOURCES/patches/DEBIAN_4/0001-use-bundled-openssl.patch
@@ -19,7 +19,7 @@ diff -Naur debian/rules debian/rules
  	cd SOURCES && ./perl-prepare.sh $(CURDIR)/SOURCES/fusioninventory-agent
 +	# Compile and install OpenSSL
 +	cd SOURCES/openssl-source && ./config -fPIC --prefix=/opt/rudder --openssldir=/opt/rudder/openssl shared
-+	cd SOURCES/openssl-source && make %{?_smp_mflags}
++	cd SOURCES/openssl-source && make
 +	cd SOURCES/openssl-source && make install INSTALL_PREFIX=$(CURDIR)/debian/tmp
  	# Compile the LMDB library and install it in /opt/rudder
  	# LMDB source code does not know how to create destination folders, do it ourselves

--- a/rudder-agent/SOURCES/patches/UBUNTU_10_04/0001-use-bundled-openssl.patch
+++ b/rudder-agent/SOURCES/patches/UBUNTU_10_04/0001-use-bundled-openssl.patch
@@ -19,7 +19,7 @@ diff -Naur debian/rules debian/rules
  	cd SOURCES && ./perl-prepare.sh $(CURDIR)/SOURCES/fusioninventory-agent
 +	# Compile and install OpenSSL
 +	cd SOURCES/openssl-source && ./config -fPIC --prefix=/opt/rudder --openssldir=/opt/rudder/openssl shared
-+	cd SOURCES/openssl-source && make %{?_smp_mflags}
++	cd SOURCES/openssl-source && make
 +	cd SOURCES/openssl-source && make install INSTALL_PREFIX=$(CURDIR)/debian/tmp
  	# Compile the LMDB library and install it in /opt/rudder
  	# LMDB source code does not know how to create destination folders, do it ourselves


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5814

To be merged in 2.11
