### PR TITLE
Fixes #5984: Build error on RPM due to man pages being included twice

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -615,7 +615,7 @@ rm -f %{_builddir}/file.list.%{name}
 %files -n rudder-agent -f %{_builddir}/file.list.%{name}
 %defattr(-, root, root, 0755)
 %config(noreplace) %{rudderdir}/etc/uuid.hive
-%{rudderdir}/share/man
+
 %if "%{?_os}" != "aix"
 /etc/profile.d/rudder-agent.sh
 /etc/init.d/rudder-agent


### PR DESCRIPTION
We do not need to include any files from %{rudderdir} in the %files
section of the .spec file, because they are included automatically (see
the comment just before the start of the %files section)
