### PR TITLE
Fixes #6033: Update Debian 8 patch for rudder-agent (local LMDB usage)

### DIFF
--- a/rudder-agent/SOURCES/patches/DEBIAN_8/0001-use-lmdb-from-packages.patch
+++ b/rudder-agent/SOURCES/patches/DEBIAN_8/0001-use-lmdb-from-packages.patch
@@ -1,7 +1,8 @@
-diff -Naur debian/control debian/control
---- debian/control	2014-10-14 12:33:00.341007179 +0200
-+++ debian/control	2014-10-14 19:06:49.889776856 +0200
-@@ -2,13 +2,13 @@
+diff --git debian/control debian/control
+index a54d207..b9eae11 100644
+--- debian/control
++++ debian/control
+@@ -2,13 +2,13 @@ Source: rudder-agent
  Section: admin
  Priority: extra
  Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
@@ -17,34 +18,37 @@ diff -Naur debian/control debian/control
  # The dependencies below are defined in order to use rudder-agent
  # for the server. This will add capabilities to send inventories
  # from the server itself.
-diff -Naur debian/dirs debian/dirs
---- debian/dirs	2014-10-14 18:59:28.389854693 +0200
-+++ debian/dirs	2014-10-14 19:06:49.889776856 +0200
+diff --git debian/dirs debian/dirs
+index 030845f..5d1c62c 100644
+--- debian/dirs
++++ debian/dirs
 @@ -1,4 +1,3 @@
 -etc/ld.so.conf.d
  etc/profile.d
  opt/rudder
- var/rudder/cfengine-community
-diff -Naur debian/postinst debian/postinst
---- debian/postinst	2014-10-14 12:33:00.345007193 +0200
-+++ debian/postinst	2014-10-14 19:06:49.889776856 +0200
-@@ -27,12 +27,6 @@
- 		CFRUDDER_FIRST_INSTALL=0
- 		if [ ! -x /var/rudder/cfengine-community/bin/cf-execd ]; then CFRUDDER_FIRST_INSTALL=1; fi
+ opt/rudder/share/man/man8
+diff --git debian/postinst debian/postinst
+index 0c1f4b1..5433c97 100755
+--- debian/postinst
++++ debian/postinst
+@@ -27,12 +27,6 @@ case "$1" in
+     CFRUDDER_FIRST_INSTALL=0
+     if [ ! -x /var/rudder/cfengine-community/bin/cf-execd ]; then CFRUDDER_FIRST_INSTALL=1; fi
  
--		# Reload the linker cache (to acknowledge LMDB's presence if needed)
--		if [ -e /etc/ld.so.conf.d/rudder.conf ]; then
--			echo "Found /etc/ld.so.conf.d/rudder.conf, running ldconfig" >> /var/log/rudder/install/rudder-agent.log
--			ldconfig -v >> /var/log/rudder/install/rudder-agent.log 2>&1
--		fi
+-    # Reload the linker cache (to acknowledge LMDB's presence if needed)
+-    if [ -e /etc/ld.so.conf.d/rudder.conf ]; then
+-      echo "Found /etc/ld.so.conf.d/rudder.conf, running ldconfig" >> /var/log/rudder/install/rudder-agent.log
+-      ldconfig -v >> /var/log/rudder/install/rudder-agent.log 2>&1
+-    fi
 -
- 		echo "Making sure that the permissions on the CFEngine key directory are correct..."
+     echo "Making sure that the permissions on the CFEngine key directory are correct..."
      if [ -d /var/rudder/cfengine-community/ppkeys ]; then
- 		chmod 700 /var/rudder/cfengine-community/ppkeys
-diff -Naur debian/rules debian/rules
---- debian/rules	2014-10-14 19:12:29.981866102 +0200
-+++ debian/rules	2014-10-14 19:12:39.581860944 +0200
-@@ -14,19 +14,12 @@
+     chmod 700 /var/rudder/cfengine-community/ppkeys
+diff --git debian/rules debian/rules
+index 43a3479..7aaab52 100755
+--- debian/rules
++++ debian/rules
+@@ -13,19 +13,12 @@
  configure: configure-stamp
  configure-stamp:
  	dh_testdir
@@ -65,7 +69,7 @@ diff -Naur debian/rules debian/rules
  
  	touch configure-stamp
  
-@@ -57,6 +50,7 @@
+@@ -55,6 +48,7 @@ clean:
  install: build
  	dh_testdir
  	dh_testroot
@@ -73,8 +77,8 @@ diff -Naur debian/rules debian/rules
  	dh_installdirs
  
  	# Add here commands to install the package into debian/tmp
-@@ -88,9 +82,6 @@
- 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES initial-promises /opt/rudder/share
+@@ -88,9 +82,6 @@ binary-arch: install
+ 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/rudder-agent-utilities/share commands /opt/rudder/share
  	# Install an empty uuid.hive file before generating an uuid
  	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ uuid.hive /opt/rudder/etc/
 -	# Install /etc/ld.so.conf.d/rudder.conf in order to use libraries contain
@@ -83,7 +87,7 @@ diff -Naur debian/rules debian/rules
  	# Install a verification script for cron
  	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ check-rudder-agent /opt/rudder/bin/
  	# Install script to get local processes on VZ systems
-@@ -105,7 +96,7 @@
+@@ -105,7 +96,7 @@ binary-arch: install
  	dh_compress
  	dh_fixperms
  #	dh_perl


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/6033

To be merged in 3.0
