### PR TITLE
Bug 6095/int/6095 do not use fortify source during cfengine build

### DIFF
--- a/rudder-agent-thin/SOURCES/patches/rudder-agent-thin/0002-rudder-agent-to-rudder-agent-thin-spec.patch
+++ b/rudder-agent-thin/SOURCES/patches/rudder-agent-thin/0002-rudder-agent-to-rudder-agent-thin-spec.patch
@@ -95,8 +95,8 @@
 -%{_sourcedir}/perl-prepare.sh %{_sourcedir}/fusioninventory-agent
 -
  # Ensure an appropriate environment for the compiler
- export CFLAGS="$RPM_OPT_FLAGS"
- export CXXFLAGS="$RPM_OPT_FLAGS"
+ export CFLAGS=$(echo ${RPM_OPT_FLAGS}|sed -e "s/-D_FORTIFY_SOURCE=.//")
+ export CXXFLAGS="${CFLAGS}"
 @@ -365,9 +349,6 @@
  # Initial promises
  cp -r %{_sourcedir}/initial-promises %{buildroot}%{rudderdir}/share/

--- a/rudder-agent-thin/SOURCES/patches/rudder-agent-thin/0002-rudder-agent-to-rudder-agent-thin-spec.patch
+++ b/rudder-agent-thin/SOURCES/patches/rudder-agent-thin/0002-rudder-agent-to-rudder-agent-thin-spec.patch
@@ -95,8 +95,8 @@
 -%{_sourcedir}/perl-prepare.sh %{_sourcedir}/fusioninventory-agent
 -
  # Ensure an appropriate environment for the compiler
- export CFLAGS="echo ${RPM_OPT_FLAGS}|sed -e "s/-D_FORTIFY_SOURCE=.//""
- export CXXFLAGS="${CFLAGS}"
+ export CFLAGS="$RPM_OPT_FLAGS"
+ export CXXFLAGS="$RPM_OPT_FLAGS"
 @@ -365,9 +349,6 @@
  # Initial promises
  cp -r %{_sourcedir}/initial-promises %{buildroot}%{rudderdir}/share/

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -243,8 +243,8 @@ cd %{_sourcedir}
 %{_sourcedir}/perl-prepare.sh %{_sourcedir}/fusioninventory-agent
 
 # Ensure an appropriate environment for the compiler
-export CFLAGS="echo ${RPM_OPT_FLAGS}|sed -e "s/-D_FORTIFY_SOURCE=.//""
-export CXXFLAGS="${CFLAGS}"
+export CFLAGS="$RPM_OPT_FLAGS"
+export CXXFLAGS="$RPM_OPT_FLAGS"
 
 %if "%{use_system_openssl}" != "true"
 # Compile and install OpenSSL

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -243,8 +243,8 @@ cd %{_sourcedir}
 %{_sourcedir}/perl-prepare.sh %{_sourcedir}/fusioninventory-agent
 
 # Ensure an appropriate environment for the compiler
-export CFLAGS="$RPM_OPT_FLAGS"
-export CXXFLAGS="$RPM_OPT_FLAGS"
+export CFLAGS=$(echo ${RPM_OPT_FLAGS}|sed -e "s/-D_FORTIFY_SOURCE=.//")
+export CXXFLAGS="${CFLAGS}"
 
 %if "%{use_system_openssl}" != "true"
 # Compile and install OpenSSL


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/6095

To be merged in 3.0