### PR TITLE
Fixes #6119: Agent regenerates the list of package available to install several time per run, causing massive performance hit

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/0013-software_packages-regenerated-every-time.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/0013-software_packages-regenerated-every-time.patch
@@ -1,0 +1,23 @@
+commit 6b3e4608cff3624592ea7e0e901a0f0634f31a2b
+Author: Kristian Amlie <kristian.amlie@cfengine.com>
+Date:   Fri Aug 1 09:20:27 2014 +0200
+
+    Redmine #6441: Fix software_packages.csv being regenerated every time.
+    
+    Do not allow '\r' to make it into the package string. If the package
+    manager puts '\r' at the end of the lines, it will cause later
+    comparisons to fail, so make sure to filter it out.
+
+diff --git a/cf-agent/verify_packages.c b/cf-agent/verify_packages.c
+index 999ca45..0a1a54f 100644
+--- a/cf-agent/verify_packages.c
++++ b/cf-agent/verify_packages.c
+@@ -818,7 +818,7 @@ static PackageItem *GetCachedPackageList(EvalContext *ctx, PackageManager *manag
+             }
+         }
+         ++linenumber;
+-        int scancount = sscanf(line, "%250[^,],%250[^,],%250[^,],%250[^\n]", name, version, arch, mgr);
++        int scancount = sscanf(line, "%250[^,],%250[^,],%250[^,],%250[^\r\n]", name, version, arch, mgr);
+         if (scancount != 4)
+         {
+             Log(LOG_LEVEL_VERBOSE, "Could only read %d values from line %d in '%s'", scancount, linenumber, name);


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6119