### PR TITLE
Fixes #6210: Do not run dh_shlibdeps and dh_prep during rudder-inventory...

### DIFF
--- a/rudder-inventory-ldap/debian/rules
+++ b/rudder-inventory-ldap/debian/rules
@@ -43,7 +43,6 @@ clean:
 install: build
 	dh_testdir
 	dh_testroot
-	dh_prep  
 	dh_installdirs
 
 	# Add here commands to install the package
@@ -90,7 +89,7 @@ binary-arch: install
 #	dh_perl
 #	dh_makeshlibs
 	dh_installdeb
-	dh_shlibdeps
+#	dh_shlibdeps
 	dh_gencontrol
 	dh_md5sums
 	dh_builddeb


### PR DESCRIPTION
...-ldap build

Ticket: http://www.rudder-project.org/redmine/issues/6210

To be merged in 2.10