### PR TITLE
Fixes #6212: mkdir the manpages directory on Debian during rudder-agent ...

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -268,7 +268,7 @@ make install DESTDIR=%{buildroot} STRIP=""
 # CFEngine man pages
 for binary in cf-agent cf-promises cf-key cf-execd cf-serverd cf-monitord cf-runagent
 do
-  ${binary}/${binary} -M | gzip > %{buildroot}%{rudderdir}/share/man/man8/${binary}.8.gz
+  LD_LIBRARY_PATH="%{buildroot}%{rudderdir}/lib" ${binary}/${binary} -M | gzip > %{buildroot}%{rudderdir}/share/man/man8/${binary}.8.gz
 done
 
 # Init script

--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -54,8 +54,9 @@ install: build
 	cd SOURCES/cfengine-source && make install DESTDIR=$(CURDIR)/debian/tmp
 
 	# Add the CFEngine man pages in debian/tmp
+	mkdir $(CURDIR)/debian/tmp/opt/rudder/share/man/man8
 	cd SOURCES/cfengine-source && for binary in cf-agent cf-promises cf-key cf-execd cf-serverd cf-monitord cf-runagent; do \
-		$${binary}/$${binary} -M | gzip > $(CURDIR)/debian/tmp/opt/rudder/share/man/man8/$${binary}.8.gz ; \
+		LD_LIBRARY_PATH="$(CURDIR)/debian/tmp/opt/rudder/lib" $${binary}/$${binary} -M | gzip > $(CURDIR)/debian/tmp/opt/rudder/share/man/man8/$${binary}.8.gz ; \
 	done
 
 # Build architecture-independent files here.


### PR DESCRIPTION
...build, and use LD_LIBRARY_PATH to find LMDB

Ticket: http://www.rudder-project.org/redmine/issues/6212

To be merged in 2.10