### PR TITLE
Fixes #6239: Run shlibdeps properly on rudder-agent and remove useless r...

### DIFF
--- a/rudder-agent/debian/postinst
+++ b/rudder-agent/debian/postinst
@@ -50,18 +50,14 @@ case "$1" in
     NB_COPIED_BINARIES=`ls -1 /var/rudder/cfengine-community/bin/ | wc -l`
     if [ ${NB_COPIED_BINARIES} -gt 0 ];then echo "CFEngine binaries copied to workdir"; fi
 
-    # Copy initial promises if there aren't any already
-    if [ ! -e /var/rudder/cfengine-community/inputs/promises.cf ]
-    then
-      cp -r /opt/rudder/share/initial-promises/* /var/rudder/cfengine-community/inputs
-    fi
-
-    # If the cf-promises validation fails, it means we have a broken set of promises (possibly a pre-2.8 set).
+    # Copy initial promises if there aren't any already or,
+    # if the cf-promises validation fails, it means we have a broken set of promises (possibly a pre-2.8 set).
     # Reset the initial promises so the server is able to send the agent a new set of correct ones.
-    RUDDER_UUID=`cat /opt/rudder/etc/uuid.hive 2>/dev/null || true`
-    if ! /var/rudder/cfengine-community/bin/cf-promises >/dev/null 2>&1 && [ "z${RUDDER_UUID}" != "zroot" ]
+    RUDDER_UUID=$(cat /opt/rudder/etc/uuid.hive 2>/dev/null || true)
+    if [ ! -e /var/rudder/cfengine-community/inputs/promises.cf ] || ! /var/rudder/cfengine-community/bin/cf-promises >/dev/null 2>&1 && [ "z${RUDDER_UUID}" != "zroot" ]
     then
-      rsync --delete -aq /opt/rudder/share/initial-promises/ /var/rudder/cfengine-community/inputs/
+      rm -rf /var/rudder/cfengine-community/inputs/* || true
+      cp -r /opt/rudder/share/initial-promises/* /var/rudder/cfengine-community/inputs/
     fi
 
     # Migration to CFEngine 3.5: Correct a specific Technique that breaks the most recent CFEngine versions

--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -100,7 +100,7 @@ binary-arch: install
 #	dh_perl
 #	dh_makeshlibs
 	dh_installdeb
-	dh_shlibdeps
+	dh_shlibdeps -- --ignore-missing-info
 	dh_gencontrol
 	dh_md5sums
 	dh_builddeb


### PR DESCRIPTION
...sync dependency

Ticket: http://www.rudder-project.org/redmine/issues/6239

To be merged in 2.10