### PR TITLE
Fixes #6399: Correct ncf-api-virtualenv conffiles on Debian packages

### DIFF
--- a/ncf-api-virtualenv/debian/conffiles
+++ b/ncf-api-virtualenv/debian/conffiles
@@ -1,1 +1,1 @@
-/etc/apache2/conf.d/ncf-api-virtualenv.conf
+/etc/apache2/conf-available/ncf-api-virtualenv.conf

--- a/ncf-api-virtualenv/debian/dirs
+++ b/ncf-api-virtualenv/debian/dirs
@@ -1,2 +1,2 @@
 usr/share/ncf-api-virtualenv
-etc/apache2/conf.d
+etc/apache2/conf-available


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/6399

To be merged in 2.11