### PR TITLE
Fixes #6486: Correct SLES Service Pack identification in detect_os.sh

### DIFF
--- a/detect_os.sh
+++ b/detect_os.sh
@@ -36,7 +36,7 @@ if [ "z$(uname -s)" = "zAIX" ]; then
 elif [ -f /etc/SuSE-release ]; then
   export OS="SLES"
   export OSVERSION=$(cat /etc/SuSE-release | grep VERSION | cut -f2 -d '=' | sed 's/ //')
-  export OSSP=$(/etc/SuSE-release | grep PATCHLEVEL | cut -f2 -d '=' | sed 's/ //')
+  export OSSP=$(cat /etc/SuSE-release | grep PATCHLEVEL | cut -f2 -d '=' | sed 's/ //')
 elif [ -f /etc/fedora-release ]; then
   export OS="FEDORA"
   export OSVERSION=$(cat /etc/fedora-release | sed 's/^.* release \([^\.][^\.]\).*$/\1/')


### PR DESCRIPTION
Fixed missing "cat" in detect_os.sh for SLES SP's

Ticket:  http://www.rudder-project.org/redmine/issues/6486

This PR is only a retarget of #632