### PR TITLE
Fixes #6632: Install the init scripts we need without dh_installinit

### DIFF
--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -83,6 +83,11 @@ binary-arch: install
 #	dh_installlogrotate
 #	dh_installmime
 #	dh_python
+        # Init script and configuration files
+	cp -f $(CURDIR)/SOURCES/rudder-agent.default $(CURDIR)/BUILD/rudder-agent
+	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-agent /etc/default/
+	cp -f $(CURDIR)/SOURCES/rudder-agent.init $(CURDIR)/BUILD/rudder-agent
+	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-agent /etc/init.d/
 	dh_installinit --name=rudder --no-start -R # restart after upgrade (instead of stop, upgrade, start)
 	# Install the profile.d file (PATH adjustment)
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-agent.sh /etc/profile.d

--- a/rudder-inventory-ldap/debian/rules
+++ b/rudder-inventory-ldap/debian/rules
@@ -69,6 +69,11 @@ binary-arch: install
 	dh_installdocs
 	dh_installexamples
 	dh_install
+	# Init script and configuration files
+	cp -f $(CURDIR)/SOURCES/rudder-inventory-ldap.default $(CURDIR)/BUILD/rudder-inventory-ldap
+	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-inventory-ldap /etc/default/
+	cp -f $(CURDIR)/SOURCES/rudder-inventory-ldap.init $(CURDIR)/BUILD/rudder-inventory-ldap
+	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-inventory-ldap /etc/init.d/
 	dh_install SOURCES/rsyslog/rudder-slapd.conf /etc/rsyslog.d/
 	# Install /etc/ld.so.conf.d/rudder.conf in order to use libraries contain
 	# in /opt/rudder/lib like BerkeleyDB

--- a/rudder-jetty/SOURCES/Makefile
+++ b/rudder-jetty/SOURCES/Makefile
@@ -70,6 +70,7 @@ localdepends: ./jetty7
 	# Provide jetty's init script to the debian package's standard location
 	cp ./jetty7/bin/jetty-debian.sh ../debian/rudder-jetty.init
 	cp ./rudder-jetty.default ../debian/rudder-jetty.default
+	chmod +x ../debian/rudder-jetty.init
 
 /usr/bin/wget:
 	sudo aptitude --assume-yes install wget

--- a/rudder-jetty/debian/rules
+++ b/rudder-jetty/debian/rules
@@ -46,6 +46,11 @@ binary-arch: build install
 	dh_installchangelogs
 #	dh_installdocs
 #	dh_installexamples
+	# Init script and configuration files
+	cp -f $(CURDIR)/SOURCES/rudder-jetty.default $(CURDIR)/BUILD/rudder-jetty
+	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-jetty /etc/default/
+	cp -f $(CURDIR)/SOURCES/rudder-jetty.init $(CURDIR)/BUILD/rudder-jetty
+	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-jetty /etc/init.d/
 	dh_install --sourcedir=$(CURDIR)/SOURCES jetty7 /opt/rudder
 	dh_install --sourcedir=$(CURDIR)/SOURCES rudder-jetty.conf /opt/rudder/etc
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-jetty /opt/rudder/etc/server-roles.d/


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/6632

To be merged in 3.1