### PR TITLE
Fixes #6670: Package rudder-jetty init script are not correctly named and packaged

### DIFF
--- a/rudder-jetty/debian/rules
+++ b/rudder-jetty/debian/rules
@@ -47,9 +47,9 @@ binary-arch: build install
 #	dh_installdocs
 #	dh_installexamples
 	# Init script and configuration files
-	cp -f $(CURDIR)/SOURCES/rudder-jetty.default $(CURDIR)/BUILD/rudder-jetty
+	cp -f $(CURDIR)/debian/rudder-jetty.default $(CURDIR)/BUILD/rudder-jetty
 	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-jetty /etc/default/
-	cp -f $(CURDIR)/SOURCES/rudder-jetty.init $(CURDIR)/BUILD/rudder-jetty
+	cp -f $(CURDIR)/debian/rudder-jetty.init $(CURDIR)/BUILD/rudder-jetty
 	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-jetty /etc/init.d/
 	dh_install --sourcedir=$(CURDIR)/SOURCES jetty7 /opt/rudder
 	dh_install --sourcedir=$(CURDIR)/SOURCES rudder-jetty.conf /opt/rudder/etc


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6670