### PR TITLE
Fixes #6765: rudder-jetty init script fails to get openjdk version

### DIFF
--- a/rudder-jetty/SOURCES/patches/jetty/jetty-init-check-java-version.patch
+++ b/rudder-jetty/SOURCES/patches/jetty/jetty-init-check-java-version.patch
@@ -9,7 +9,7 @@
 +# with Rudder
 +##################################################
 +
-+JAVA_VERSION=$(${JAVA} -version 2>&1 | grep "java version" | sed 's%java version \"[0-9]\.\([0-9]\)\.[0-9].*\"%\1%')
++JAVA_VERSION=$(${JAVA} -version 2>&1 | grep -E "(java|openjdk) version" | sed 's%.*version \"[0-9]\.\([0-9]\)\.[0-9].*\"%\1%')
 +
 +if [ ${JAVA_VERSION} -lt 7 ]
 +then


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6765