### PR TITLE
Fixes #6919: Get rudder-relay-apache-common from SOURCES not BUILD

### DIFF
--- a/rudder-server-relay/debian/rules
+++ b/rudder-server-relay/debian/rules
@@ -53,7 +53,7 @@ binary-arch: install
 	cp $(CURDIR)/SOURCES/rudder-relay-vhost-ssl.conf $(CURDIR)/BUILD/rudder-relay-vhost-ssl
 	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-relay-vhost /etc/apache2/sites-available/
 	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-relay-vhost-ssl /etc/apache2/sites-available/
-	dh_install --SOURCEDIR=$(CURDIR)/BUILD/ rudder-relay-apache-common.conf /opt/rudder/etc/
+	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-relay-apache-common.conf /opt/rudder/etc/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-networks.conf /opt/rudder/etc/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-networks-24.conf /opt/rudder/etc/
 #	dh_installmenu


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6919