### PR TITLE
Fixes #6930: Upgrades to 3.1 fail due to a wrong /etc/default/rudder-jetty file

### DIFF
--- a/rudder-jetty/debian/postinst
+++ b/rudder-jetty/debian/postinst
@@ -24,8 +24,8 @@ case "$1" in
         # Migrate old /opt/rudder/etc/rudder-jetty.conf entries
         if [ -e /opt/rudder/etc/rudder-jetty.conf.migrate ]
         then
-            JAVA_XMX_MIGRATE=$(grep '^JAVA_XMX=' /opt/rudder/etc/rudder-jetty.conf.migrate|cut -d = -f 2)
-            JAVA_MAXPERMSIZE_MIGRATE=$(grep '^JAVA_MAXPERMSIZE=' /opt/rudder/etc/rudder-jetty.conf.migrate|cut -d = -f 2)
+            JAVA_XMX_MIGRATE=$(grep '^JAVA_XMX=' /opt/rudder/etc/rudder-jetty.conf.migrate|cut -d = -f 2-)
+            JAVA_MAXPERMSIZE_MIGRATE=$(grep '^JAVA_MAXPERMSIZE=' /opt/rudder/etc/rudder-jetty.conf.migrate|cut -d = -f 2-)
 
             cat > /etc/default/rudder-jetty << EOF
 #

--- a/rudder-jetty/debian/preinst
+++ b/rudder-jetty/debian/preinst
@@ -19,7 +19,7 @@ case "$1" in
 
         # Prepare the migration of /etc/default/rudder-jetty
         if [ -f /opt/rudder/etc/rudder-jetty.conf ]; then
-          if [ $(grep -c '# WARNING #' /opt/rudder/etc/rudder-jetty.conf) -eq 0 ]; then
+          if [ $(head -n 1 /opt/rudder/etc/rudder-jetty.conf | grep -c 'WARNING') -eq 0 ]; then
             cp /opt/rudder/etc/rudder-jetty.conf /opt/rudder/etc/rudder-jetty.conf.migrate
           fi
         fi


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6930