### PR TITLE
Fixes #6915: cf-agent writes incorrect files when the server answers too slowly during recursive copy

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/0016-close-connection-after-timeout.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/0016-close-connection-after-timeout.patch
@@ -1,0 +1,11 @@
+diff -ur a/libcfnet/classic.c b/libcfnet/classic.c
+--- a/libcfnet/classic.c	2014-06-03 14:39:00.000000000 +0200
++++ b/libcfnet/classic.c	2015-07-07 09:41:57.058600817 +0200
+@@ -77,6 +77,7 @@
+             }
+             else if (LastRecvTimedOut())
+             {
++                close(sd);
+                 Log(LOG_LEVEL_ERR,
+                     "Timeout - remote end did not respond with the expected amount of data (received=%d, expecting=%d). (recv: %s)",
+                     already, toget, GetErrorStr());


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6915