### PR TITLE
Fixes #6934: cf-agent writes incorrect files when the server answers too slowly during recursive copy on 3.5.3

### DIFF
--- a/rudder-agent/SOURCES/0007-close-connection-after-timeout.patch
+++ b/rudder-agent/SOURCES/0007-close-connection-after-timeout.patch
@@ -1,0 +1,11 @@
+diff -ur a/libcfnet/net.c b/libcfnet/net.c
+--- a/libcfnet/net.c	2013-12-09 13:13:14.000000000 +0100
++++ b/libcfnet/net.c	2015-07-07 10:22:14.624779845 +0200
+@@ -148,6 +148,7 @@
+ 
+         if ((got == -1) && (LastRecvTimedOut()))
+         {
++            close(sd);
+             Log(LOG_LEVEL_ERR, "Timeout - remote end did not respond with the expected amount of data (received=%d, expecting=%d). (recv: %s)",
+                 already, toget, GetErrorStr());
+             return -1;

--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -45,6 +45,7 @@ localdepends: ./initial-promises ./detect_os.sh ./files ./fusioninventory-agent 
 	$(PATCH) -d ./cfengine-source -p1 < ./0004-Make-safe_open-treat-trailing-slashes-like-open.patch
 	$(PATCH) -d ./cfengine-source -p1 < ./0005-dont-duplicate-text-blocks.patch
 	$(PATCH) -d ./cfengine-source -p1 < ./0006-support-large-int.patch
+	$(PATCH) -d ./cfengine-source -p1 < ./0007-close-connection-after-timeout.patch
 
 ./tokyocabinet-source: /usr/bin/wget
 	# Original URL: http://fallabs.com/tokyocabinet/tokyocabinet-${TOKYOCABINET_RELEASE}.tar.gz


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6934