### PR TITLE
Fixes #7088: Unable to build ncf-api-virtualenv since rudderdir does not exists in spec

### DIFF
--- a/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
+++ b/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
@@ -185,7 +185,7 @@ install -m 644 %{SOURCE2} %{buildroot}%{apache_vhost_dir}/
 
 %if 0%{?rhel} || 0%{?fedora}
 # Install SELinux policy
-install -m 644  %{_builddir}/ncf-api-virtualenv.pp %{buildroot}%{rudderdir}/share/selinux/
+install -m 644  %{_builddir}/ncf-api-virtualenv.pp %{buildroot}%{installdir}/share/selinux/
 %endif
 
 %post -n ncf-api-virtualenv
@@ -207,7 +207,7 @@ fi
 if type sestatus >/dev/null 2>&1
 then
   # Add/Update the ncf-api-virtualenv SELinux policy
-  semodule -i /opt/rudder/share/selinux/ncf-api-virtualenv.pp 2>/dev/null
+  semodule -i %{installdir}/share/selinux/ncf-api-virtualenv.pp 2>/dev/null
 fi
 %endif
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7088