### PR TITLE
Fixes #7089: ncf-api-virtualenv package does not create its own 'share/selinux' directory

### DIFF
--- a/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
+++ b/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
@@ -173,6 +173,7 @@ rm -rf %{buildroot}
 # Directories
 
 mkdir -p %{buildroot}%{installdir}/
+mkdir -p %{buildroot}%{installdir}/share/selinux/
 mkdir -p %{buildroot}%{apache_vhost_dir}/
 mkdir -p %{buildroot}/var/lib/%{user_name}/
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7089