### PR TITLE
Fixes #7090: Wrong buidl directory when building selinux policy for ncf-api-virtualenv

### DIFF
--- a/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
+++ b/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
@@ -120,7 +120,7 @@ of the ncf API easier.
 %prep
 
 # Copy the required source files to the build directory
-cp -f %{SOURCE3} %{buildroot}
+cp -f %{SOURCE3} %{_builddir}
 
 #=================================================
 # Building
@@ -160,7 +160,7 @@ fi
 
 %if 0%{?rhel} || 0%{?fedora}
 # Build SELinux policy package
-cd %{buildroot} && make -f /usr/share/selinux/devel/Makefile
+cd %{_builddir} && make -f /usr/share/selinux/devel/Makefile
 %endif
 
 #=================================================


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7090