### PR TITLE
Fixes #7099: When upgrading rudder agent from 2.10.16 to 2.11.13, on debian squeeze, the file /opt/rudder/etc/disable-agent is set, preventing any further agent execution

### DIFF
--- a/rudder-agent/debian/postinst
+++ b/rudder-agent/debian/postinst
@@ -68,23 +68,6 @@ case "$1" in
       cp -r /opt/rudder/share/initial-promises/* /var/rudder/cfengine-community/inputs/
     fi
 
-    # Copy new binaries to workdir, make sure daemons are stopped first
-
-    # Set a "lock" to avoid CFEngine being restarted during the upgrade process
-    I_SET_THE_LOCK=0
-    if [ ! -e /opt/rudder/etc/disable-agent ]; then
-      I_SET_THE_LOCK=1
-      touch /opt/rudder/etc/disable-agent
-    fi
-
-    if [ ${CFRUDDER_FIRST_INSTALL} -ne 1 -a -x /etc/init.d/rudder-agent ]; then /etc/init.d/rudder-agent stop || /etc/init.d/rudder-agent forcestop; fi
-
-    # Copy CFEngine binaries (Changed location from sbin/ to bin/ in version 3.4)
-    cp -a -f /opt/rudder/bin/cf-* /var/rudder/cfengine-community/bin/
-    cp -a -f /opt/rudder/bin/rpmvercmp /var/rudder/cfengine-community/bin/
-    NB_COPIED_BINARIES=`ls -1 /var/rudder/cfengine-community/bin/ | wc -l`
-    if [ ${NB_COPIED_BINARIES} -gt 0 ];then echo "CFEngine binaries copied to workdir"; fi
-
     # Create a key if we don't have one yet
     if [ ! -f /var/rudder/cfengine-community/ppkeys/localhost.priv ]
     then


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7099