### PR TITLE
Fixes #7166: Migrations to 3.1 may fail due to a wrong Jetty configuration migration on RPM based systems

### DIFF
--- a/rudder-jetty/SPECS/rudder-jetty.spec
+++ b/rudder-jetty/SPECS/rudder-jetty.spec
@@ -176,8 +176,8 @@ fi
 # Migrate old /opt/rudder/etc/rudder-jetty.conf entries
 if [ -e /opt/rudder/etc/rudder-jetty.conf.migrate ]
 then
-    JAVA_XMX_MIGRATE=$(grep '^JAVA_XMX=' /opt/rudder/etc/rudder-jetty.conf.migrate|cut -d = -f 2)
-    JAVA_MAXPERMSIZE_MIGRATE=$(grep '^JAVA_MAXPERMSIZE=' /opt/rudder/etc/rudder-jetty.conf.migrate|cut -d = -f 2)
+    JAVA_XMX_MIGRATE=$(grep '^JAVA_XMX=' /opt/rudder/etc/rudder-jetty.conf.migrate|cut -d = -f 2-)
+    JAVA_MAXPERMSIZE_MIGRATE=$(grep '^JAVA_MAXPERMSIZE=' /opt/rudder/etc/rudder-jetty.conf.migrate|cut -d = -f 2-)
 
     cat > /etc/default/rudder-jetty << EOF
 #


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7166