### PR TITLE
Fixes #7249: Invalid variable name for vzps command in check/init script of rudder-agent

### DIFF
--- a/rudder-agent/SOURCES/check-rudder-agent
+++ b/rudder-agent/SOURCES/check-rudder-agent
@@ -71,7 +71,7 @@ check_and_fix_cfengine_processes() {
   ns=$(ps -h -o utsns --pid $$ 2>/dev/null)
   if [ -e "/proc/bc/0" ]; then # we have openvz
     if [ -e /bin/vzps ]; then # we have vzps
-      PS_COMAND="/bin/vzps -E 0"
+      PS_COMMAND="/bin/vzps -E 0"
     else # use rudder provided vzps
       PS_COMMAND="/opt/rudder/bin/vzps.py -E 0"
     fi

--- a/rudder-agent/SOURCES/rudder-agent.init
+++ b/rudder-agent/SOURCES/rudder-agent.init
@@ -70,7 +70,7 @@ SYSLOG_FACILITY="local6"
 ns=$(ps -h -o utsns --pid $$ 2>/dev/null)
 if [ -e "/proc/bc/0" ]; then # we have openvz
   if [ -e /bin/vzps ]; then # we have vzps
-    PS_COMAND="/bin/vzps -E 0"
+    PS_COMMAND="/bin/vzps -E 0"
   else # use rudder provided vzps
     PS_COMMAND="/opt/rudder/bin/vzps.py -E 0"
   fi


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7249