### PR TITLE
Fixes #7276: cfengine 3.6.0 doesn't compile with -Werror=format-security

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/0019-sprintf-format-string-vulnerability.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/0019-sprintf-format-string-vulnerability.patch
@@ -1,0 +1,12 @@
+diff -ruN a/libpromises/bootstrap.c b/libpromises/bootstrap.c
+--- a/libpromises/bootstrap.c	2015-10-13 17:35:39.642877282 +0200
++++ b/libpromises/bootstrap.c	2015-10-13 17:35:05.902878242 +0200
+@@ -298,7 +298,7 @@
+         return false;
+     }
+ 
+-    fprintf(fout, bootstrap_content);
++    fprintf(fout, "%s", bootstrap_content);
+     fclose(fout);
+ 
+     if (chmod(filename, S_IRUSR | S_IWUSR) == -1)


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7276