### PR TITLE
Fixes #7337: Typo in rudder-agent spec file: %fi instead of %endif

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -332,7 +332,7 @@ service_start_cmd="/usr/bin/startsrc -s rudder-agent"
 %else
 service_stop_cmd="service rudder-agent stop || service rudder-agent forcestop"
 service_start_cmd="service rudder-agent start"
-%fi
+%endif
 
 /opt/rudder/share/package-scripts/rudder-agent-postinst "${CFRUDDER_FIRST_INSTALL}" "${service_stop_cmd}" "${service_start_cmd}"
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7337