### PR TITLE
Fixes #7335: check-rudder-agent silently fails if namespaces are not supported

### DIFF
--- a/rudder-agent/SOURCES/check-rudder-agent
+++ b/rudder-agent/SOURCES/check-rudder-agent
@@ -68,7 +68,7 @@ clean_cf_lock_files() {
 check_and_fix_cfengine_processes() {
 
   # Detect the correct ps tool to use
-  ns=$(ps -h -o utsns --pid $$ 2>/dev/null)
+  ns=$(ps --no-header -o utsns --pid $$ 2>/dev/null || true)
   if [ -e "/proc/bc/0" ]; then # we have openvz
     if [ -e /bin/vzps ]; then # we have vzps
       PS_COMMAND="/bin/vzps -E 0"

--- a/rudder-agent/SOURCES/rudder-agent.init
+++ b/rudder-agent/SOURCES/rudder-agent.init
@@ -67,7 +67,7 @@ MYUID=`id -u`     # For UNIX compatibility => modify this command
 MYGID=`id -g`     # For UNIX compatibility => modify this command
 SYSLOG_FACILITY="local6"
 # Detect the correct ps tool to use
-ns=$(ps -h -o utsns --pid $$ 2>/dev/null)
+ns=$(ps --no-header -o utsns --pid $$ 2>/dev/null || true)
 if [ -e "/proc/bc/0" ]; then # we have openvz
   if [ -e /bin/vzps ]; then # we have vzps
     PS_COMMAND="/bin/vzps -E 0"


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7335