### PR TITLE
Fixes #7418: \"semanage: command not found\" error during ncf-api-virtualenv package installation on RHEL/Fedora systems

### DIFF
--- a/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
+++ b/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
@@ -80,11 +80,16 @@ AutoProv: 0
 BuildRequires: python
 Requires: python ncf
 
-# We need mod_wsgi to use ncf builder
 
 ## RHEL & Fedora
 %if 0%{?rhel} || 0%{?fedora}
+
+# We need mod_wsgi to use ncf builder
 Requires: httpd mod_wsgi shadow-utils
+
+# We need policycoreutils-python to provide the semanage command for selinux compatibility
+Requires: policycoreutils-python
+
 %endif
 
 ## SLES


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7418