### PR TITLE
Fixes #7515: rudder-agent and rudder-slapd init scripts may fail to stop services if killall is missing or misbehaving

### DIFF
--- a/rudder-agent/SOURCES/rudder-agent.init
+++ b/rudder-agent/SOURCES/rudder-agent.init
@@ -301,8 +301,12 @@ forcestop_daemons() {
 		# If the pid file is not readable or is empty, kill all process by name
 		if [ ! -r ${CFENGINE_COMMUNITY_PID_FILE[$daemon]} -o ! -s ${CFENGINE_COMMUNITY_PID_FILE[$daemon]} ]
 		then
-			# Try a killall
-			/usr/bin/killall -KILL ${CFENGINE_COMMUNITY_BIN[$daemon]}
+      if type pidof > /dev/null 2> /dev/null; then
+        kill -KILL `pidof ${CFENGINE_COMMUNITY_BIN[$daemon]}`
+      else
+        # Try a killall
+        /usr/bin/killall -KILL ${CFENGINE_COMMUNITY_BIN[$daemon]}
+      fi
 
 			if [ $? -eq 0 ]
 			then

--- a/rudder-inventory-ldap/SOURCES/rudder-inventory-ldap.init
+++ b/rudder-inventory-ldap/SOURCES/rudder-inventory-ldap.init
@@ -588,8 +588,13 @@ forcestop() {
 		then
 			message "info" "[INFO] Found no rudder-slapd process running with $SLAPD_SERVICES"
 		else
-			# Try a killall
-			/usr/bin/killall -KILL $SLAPD_BIN
+      if type pidof > /dev/null 2> /dev/null
+      then
+        kill -KILL `pidof ${SLAPD_BIN}`
+      else
+        # Try a killall
+        /usr/bin/killall -KILL ${SLAPD_BIN}
+      fi
 
 			if [ $? -eq 0 ]
 			then
@@ -623,8 +628,13 @@ forcestop() {
 		then
 			message "info" "[INFO] Found no slurpd process running"
 		else
-			# Try a killall
-			/usr/bin/killall -KILL $SLURPD_BIN
+      if type pidof > /dev/null 2> /dev/null
+      then
+        kill -KILL `pidof ${SLURPD_BIN}`
+      else
+        # Try a killall
+        /usr/bin/killall -KILL ${SLURPD_BIN}
+      fi
 
 			if [ $? -eq 0 ]
 			then


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7515