### PR TITLE
Fixes #4922: Rudder OpenLDAP Authentication sans ipv4 localhost

### DIFF
--- a/rudder-inventory-ldap/SOURCES/rudder-inventory-ldap.default
+++ b/rudder-inventory-ldap/SOURCES/rudder-inventory-ldap.default
@@ -3,7 +3,7 @@
 #========================================================
 
 # IP and port to listen
-IP="127.0.0.1"
+IP="localhost"
 SSLIP="*"
 PORT="389"
 SSLPORT="636"


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/4922