### PR TITLE
Fixes #7420: cf-execd is running twice after a reboot or after running rudder-agent twice

### DIFF
--- a/rudder-agent/SOURCES/rudder-agent.init
+++ b/rudder-agent/SOURCES/rudder-agent.init
@@ -191,6 +191,17 @@ start_daemons() {
 
 	# It's time to start the daemons
 	for daemon in ${DAEMONS}; do
+    # Test if daemon is already running
+    if [ -s ${CFENGINE_COMMUNITY_PID_FILE[$daemon]} ]
+    then
+      PID=`cat ${CFENGINE_COMMUNITY_PID_FILE[$daemon]}`
+      if [ -e /proc/$PID ]
+      then
+        message "info" "[INFO] CFEngine Community ${CFENGINE_COMMUNITY_NAME[$daemon]} Is already running"
+        continue
+      fi
+    fi
+
 		# Start message
 		message "info" "[INFO] Launching CFEngine Community ${CFENGINE_COMMUNITY_NAME[$daemon]}..."
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7420