### PR TITLE
Fixes #7593: rudder-server-relay rpm package should require rudder-agent

### DIFF
--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -72,7 +72,7 @@ BuildArch: noarch
 # Requirements
 
 ## General
-Requires: rsyslog
+Requires: rudder-agent rsyslog
 
 ## RHEL
 %if 0%{?rhel}


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/7593