### PR TITLE
Fixes #7797: Warn when the servers answers an empty string to a (S)OPENDIR

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/0025-warn-when-server-answers-to-opendir-with-empty-string.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/0025-warn-when-server-answers-to-opendir-with-empty-string.patch
@@ -1,0 +1,17 @@
+diff -upr cfengine-3.6.0/libcfnet/client_code.c cfengine-3.6.0-new/libcfnet/client_code.c
+--- cfengine-3.6.0/libcfnet/client_code.c	2014-06-11 16:13:56.000000000 +0200
++++ cfengine-3.6.0-new/libcfnet/client_code.c	2016-01-18 14:56:35.550312031 +0100
+@@ -630,6 +630,13 @@ Item *RemoteDirList(const char *dirname,
+             DecryptString(conn->encryption_type, in, recvbuffer, conn->session_key, n);
+         }
+ 
++        if (recvbuffer[0] == '\0')
++        {
++            Log(LOG_LEVEL_ERR,
++                "Empty server packet when listing directory '%s'!",
++                dirname);
++        }
++
+         if (FailedProtoReply(recvbuffer))
+         {
+             Log(LOG_LEVEL_INFO, "Network access to '%s:%s' denied", conn->this_server, dirname);


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7797