### PR TITLE
Fixes #4473: Jetty cache files in /tmp directory are removed by the OS tmpwatch cron job, preventing access to the application

### DIFF
--- a/rudder-jetty/SOURCES/rudder-jetty.default
+++ b/rudder-jetty/SOURCES/rudder-jetty.default
@@ -54,5 +54,10 @@ JETTY_RUN="/var/rudder/run"
 JETTY_ARGS="OPTIONS=Server"
 JETTY_LOGS="/var/log/rudder/webapp/"
 
+# By default, Jetty stores files it's going to *serve* under /tmp
+# This causes trouble, if tmpwatch cleans them up (or a over-zealous user)
+TMPDIR="/var/rudder/tmp/jetty"
+mkdir -p ${TMPDIR}
+
 # Prevent Jetty to change locale in its logs
 export LANG=C


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/4473