### PR TITLE
Fixes #7204: Debian Jessie, on VMWare, are wrongly considered as \"Physical\" machine

### DIFF
--- a/rudder-agent/SOURCES/patches/fusioninventory/0013-fix-vmware-detection-on-debian8.patch
+++ b/rudder-agent/SOURCES/patches/fusioninventory/0013-fix-vmware-detection-on-debian8.patch
@@ -1,0 +1,24 @@
+From d781329d9ded0fb7b7609efb72c88eae7bee05a6 Mon Sep 17 00:00:00 2001
+From: Nicolas Charles <nicolas.charles@normation.com>
+Date: Tue, 26 Jan 2016 10:16:24 +0100
+Subject: [PATCH] Fixes #3036: correct detection of vmware on debian jessie
+
+---
+ lib/FusionInventory/Agent/Task/Inventory/Virtualization/Vmsystem.pm | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Vmsystem.pm b/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Vmsystem.pm
+index e827905..100ea42 100644
+--- a/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Vmsystem.pm
++++ b/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Vmsystem.pm
+@@ -7,6 +7,7 @@ use FusionInventory::Agent::Tools;
+ use FusionInventory::Agent::Tools::Solaris;
+ 
+ my @vmware_patterns = (
++    'Hypervisor detected: VMware',
+     'VMware vmxnet virtual NIC driver',
+     'Vendor: VMware\s+Model: Virtual disk',
+     'Vendor: VMware,\s+Model: VMware Virtual ',
+-- 
+1.9.1
+


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7204