### PR TITLE
Fixes #7846: Default vhost is not disabled on rudder-relay 

### DIFF
--- a/rudder-server-relay/debian/postinst
+++ b/rudder-server-relay/debian/postinst
@@ -21,7 +21,7 @@ set -e
 case "$1" in
     configure)
 
-      SITES_TO_DISABLE="default default-ssl"
+      SITES_TO_DISABLE="default 000-default default-ssl"
       SITES_TO_ENABLE="rudder-relay-vhost"
 
       MODULES_TO_ENABLE="dav dav_fs"


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7846