### PR TITLE
Fixes #6468: When we install rudder-agent after having removing it, the uuid is not restored on RPM-based systems

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -495,20 +495,6 @@ if ! grep -q "/opt/rudder/lib" /etc/ld.so.conf; then
 fi
 %endif
 
-# Generate a UUID if we don't have one yet
-if [ ! -e /opt/rudder/etc/uuid.hive ]
-then
-  uuidgen > /opt/rudder/etc/uuid.hive
-else
-  # UUID is valid only if it has been generetaed by uuidgen or if it is set to 'root' for policy server
-  CHECK_UUID=`cat /opt/rudder/etc/uuid.hive | grep -E "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}|root" | wc -l`
-  # If the UUID is not valid, regenerate it
-  if [ ${CHECK_UUID} -ne 1 ]
-  then
-    uuidgen > /opt/rudder/etc/uuid.hive
-  fi
-fi
-
 # Copy new binaries to workdir, make sure daemons are stopped first
 
 # Set a "lock" to avoid CFEngine being restarted during the upgrade process


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6468