### PR TITLE
Fixes #8296: rudder init script fails with \"/etc/init.d/rudder: line 109: printf \033[1;32m---8<---\033[0;39m\n: command not found\"

### DIFF
--- a/rudder-agent/SOURCES/rudder.init
+++ b/rudder-agent/SOURCES/rudder.init
@@ -106,9 +106,9 @@ service_details()
 printf "\n * ${BLUE}${1}${NORMAL}:"
 if [ "${3}" -eq 1 ]; then
   echo ""
-  "${COPYPASTE}"
+  ${COPYPASTE}
   service "${2}" status || RETURN=${?}
-  "${COPYPASTE}"
+  ${COPYPASTE}
 else
   printf " ${YELLOW}Not installed${NORMAL}\n"
 fi


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8296