### PR TITLE
Fixes #8370: Makefile missing in rudder-server-relay package

### DIFF
--- a/rudder-server-relay/Makefile
+++ b/rudder-server-relay/Makefile
@@ -1,0 +1,1 @@
+include ../packages.makefile


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8370