### PR TITLE
Fixes #8371: Spurious message \"grep: /etc/sysconfig/apache2: No such file or directory\" in RPM install for rudder-webapp

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -312,7 +312,7 @@ fi
 %endif
 
 # Update /etc/sysconfig/apache2 in case an old module loading entry has already been created by Rudder
-if grep -q 'APACHE_MODULES="${APACHE_MODULES} rewrite dav dav_fs proxy proxy_http' /etc/sysconfig/apache2
+if [ -f /etc/sysconfig/apache2 ] && grep -q 'APACHE_MODULES="${APACHE_MODULES} rewrite dav dav_fs proxy proxy_http' /etc/sysconfig/apache2
 then
 	echo "INFO: Upgrading the /etc/sysconfig/apache2 file, Rudder needed modules for Apache are now listed in /etc/sysconfig/rudder-apache"
 	sed -i 's%APACHE_MODULES="${APACHE_MODULES} rewrite dav dav_fs proxy proxy_http.*%# This sources the Rudder needed by Rudder\n. /etc/sysconfig/rudder-apache%' /etc/sysconfig/apache2


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8371