### PR TITLE
Fixes #8723: command_execution_result with undefined code does not define any classes on 2.11

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/0040-assume-failed-unspecified-return-codes.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/0040-assume-failed-unspecified-return-codes.patch
@@ -1,0 +1,65 @@
+commit 7d30292fe27cca8b1ee653ffec31b3c7485fa1d7
+Author: Ted Zlatanov <tzz@lifelogs.com>
+Date:   Mon Jun 2 17:42:43 2014 -0400
+
+    Redmine#5986: fix to assume all non-specified return codes are failed
+    
+    (cherry picked from commit 4e58ff2575b51a42829c469a1d4367aabe99a012)
+
+diff --git a/cf-agent/retcode.c b/cf-agent/retcode.c
+index 1bee6e6..9357910 100644
+--- a/cf-agent/retcode.c
++++ b/cf-agent/retcode.c
+@@ -69,9 +69,11 @@ int VerifyCommandRetcode(EvalContext *ctx, int retcode, Attributes a, const Prom
+ 
+         if (!matched)
+         {
+-            Log(LOG_LEVEL_VERBOSE,
+-                "Command related to promiser '%s' returned code %d -- did not match any failed, repaired or kept lists",
+-                  pp->promiser, retcode);
++            cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_FAIL, pp, a,
++                 "Command related to promiser '%s' returned code not defined as promise kept, not kept or repaired; setting to failed: %d",
++                 pp->promiser, retcode);
++            *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
++            result_retcode = false;
+         }
+ 
+     }
+diff --git a/tests/acceptance/00_basics/03_bodies/119.cf b/tests/acceptance/00_basics/03_bodies/119.cf
+index df85f88..4f6ee3d 100644
+--- a/tests/acceptance/00_basics/03_bodies/119.cf
++++ b/tests/acceptance/00_basics/03_bodies/119.cf
+@@ -87,12 +87,12 @@ bundle agent check
+   vars:
+       "expect[promise_kept]" string        => "";
+       "expect[promise_repaired]" string        => "";
+-      "expect[repair_failed]" string        => "";
++      "expect[repair_failed]" string        => "ON";
+       "expect[repair_denied]" string        => "";
+       "expect[repair_timeout]" string        => "";
+       "expect[cancel_kept]" string        => "ON";
+       "expect[cancel_repaired]" string        => "ON";
+-      "expect[cancel_notkept]" string        => "ON";
++      "expect[cancel_notkept]" string        => "";
+ 
+       # Everything from here down is "boilerplate" to these 1xx.cf tests
+       "lookfor" slist => {
+diff --git a/tests/acceptance/00_basics/03_bodies/121.cf b/tests/acceptance/00_basics/03_bodies/121.cf
+index 25b365c..0e74333 100644
+--- a/tests/acceptance/00_basics/03_bodies/121.cf
++++ b/tests/acceptance/00_basics/03_bodies/121.cf
+@@ -87,12 +87,12 @@ bundle agent check
+   vars:
+       "expect[promise_kept]" string        => "";
+       "expect[promise_repaired]" string        => "";
+-      "expect[repair_failed]" string        => "";
++      "expect[repair_failed]" string        => "ON";
+       "expect[repair_denied]" string        => "";
+       "expect[repair_timeout]" string        => "";
+       "expect[cancel_kept]" string        => "ON";
+       "expect[cancel_repaired]" string        => "ON";
+-      "expect[cancel_notkept]" string        => "ON";
++      "expect[cancel_notkept]" string        => "";
+ 
+       # Everything from here down is "boilerplate" to these 1xx.cf tests
+       "lookfor" slist => {

--- a/rudder-agent/SOURCES/patches/cfengine/0041-test-failed-unspecified-return-codes.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/0041-test-failed-unspecified-return-codes.patch
@@ -1,0 +1,57 @@
+commit 21222256bcb839dc5413bda78ea3d62a2524b6ca
+Author: Nick Anderson <nick@cmdln.org>
+Date:   Mon Jun 2 15:32:05 2014 -0500
+
+    Add test for failed_returncodes
+    
+    When kept_returncodes or repaired_returncodes are specified
+    failed_returncode is not defaulted properly.
+    
+    (cherry picked from commit 196fa94ae1cf10d3383b11af9e7f4c3405bc8120)
+
+diff --git a/tests/acceptance/08_commands/staging/default_failed_returncodes.cf b/tests/acceptance/08_commands/staging/default_failed_returncodes.cf
+new file mode 100644
+index 0000000..4b43f90
+--- /dev/null
++++ b/tests/acceptance/08_commands/staging/default_failed_returncodes.cf
+@@ -0,0 +1,40 @@
++body common control
++{
++  inputs => { "../default.cf.sub" };
++  bundlesequence => { default("$(this.promise_filename)") };
++}
++
++bundle agent test
++{
++  commands:
++
++    "/bin/false"
++      classes => scoped_classes_generic("namespace", "default"),
++      comment => "Test that by default non zero commands return promise failure";
++
++    "/bin/false"
++      classes => scoped_classes_generic_kept_0("namespace", "specify_kept"),
++      comment => "Test that when specifying kept returncodes that failures are still registered";
++}
++
++bundle agent check
++{
++  methods:
++    "report"
++      usebundle => dcs_passif_expected("default_not_kept,specify_kept_not_kept", "", "$(this.promise_filename)")
++      inherit => "true";
++}
++
++body classes scoped_classes_generic_kept_0(scope, x)
++{
++      scope => "$(scope)";
++      promise_repaired => { "promise_repaired_$(x)", "$(x)_repaired", "$(x)_ok", "$(x)_reached" };
++      repair_failed => { "repair_failed_$(x)", "$(x)_failed", "$(x)_not_ok", "$(x)_not_kept", "$(x)_not_repaired", "$(x)_reached" };
++      repair_denied => { "repair_denied_$(x)", "$(x)_denied", "$(x)_not_ok", "$(x)_not_kept", "$(x)_not_repaired", "$(x)_reached" };
++      repair_timeout => { "repair_timeout_$(x)", "$(x)_timeout", "$(x)_not_ok", "$(x)_not_kept", "$(x)_not_repaired", "$(x)_reached" };
++      promise_kept => { "promise_kept_$(x)", "$(x)_kept", "$(x)_ok", "$(x)_not_repaired", "$(x)_reached" };
++      kept_returncodes => { "0" };
++      #repaired_returncodes => { "2" };
++      #failed_returncodes => { "1" };
++}
++


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8723