### PR TITLE
clean up os detection a little

### DIFF
--- a/detect_os.sh
+++ b/detect_os.sh
@@ -48,7 +48,7 @@ elif [ -f /etc/redhat-release ]; then
   # No Service Pack
   export OSSP=""
 elif [ -f /etc/debian_version ]; then
-  if [ -f /etc/lsb-release -a "z$(grep DISTRIB_ID /etc/lsb-release | cut -f2 -d '=' | sed 's/ //')" = "zUbuntu" ]; then
+  if [ -f /etc/lsb-release ] && [ "z$(grep DISTRIB_ID /etc/lsb-release | cut -f2 -d '=' | sed 's/ //')" = "zUbuntu" ]; then
     export OS="UBUNTU"
     # Ubuntu version is always formatted like X.Y
     export OSVERSION=$(cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -f2 -d '=' | sed 's/ //')


### PR DESCRIPTION
suppress unneeded errors on debian

```
root@coole-arm-kiste:/usr/src/rudder-packages/rudder-agent# make RUDDER_VERSION_TO_PACKAGE=3.2.4 veryclean
../packages.makefile:19: /build-package.makefile: No such file or directory
grep: /etc/lsb-release: No such file or directory
grep: /etc/lsb-release: No such file or directory
grep: /etc/lsb-release: No such file or directory
make: *** No rule to make target `/build-package.makefile'.  Stop.
```

(the 3 failing greps)