### PR TITLE
Fixes #8876: The file rsyslog.d/rudder.conf might not be embedded in rudder-reports (db on a separate server)

### DIFF
--- a/rudder-reports/SOURCES/Makefile
+++ b/rudder-reports/SOURCES/Makefile
@@ -20,7 +20,7 @@
 
 RUDDER_VERSION_TO_PACKAGE = <put Rudder version or version-snapshot here>
 
-localdepends: ./rudder-sources ./rudder.conf
+localdepends: ./rudder-sources
 
 ./rudder-sources.tar.bz2:
 	$(WGET) -O rudder-sources.tar.bz2 http://www.rudder-project.org/archives/rudder-sources-${RUDDER_VERSION_TO_PACKAGE}.tar.bz2
@@ -29,15 +29,8 @@ localdepends: ./rudder-sources ./rudder.conf
 	tar -xjf rudder-sources.tar.bz2
 	mv rudder-sources-*/ rudder-sources/
 
-./rudder.conf: ./rudder-sources
-	cp rudder-sources/rudder-techniques/initial-promises/node-server/distributePolicy/rsyslog.conf/rudder.conf rudder.conf
-	sed 's@\$${install_rsyslogd.rsyslog_port\[2\]}@514@' -i rudder.conf
-	sed 's@\$${install_rsyslogd.rudder_postgres_server}@localhost@' -i rudder.conf
-	sed 's@\$$(p.psql_password\[2\])@Normation@' -i rudder.conf
-
 localclean:
 	rm -rf ./rudder-sources
-	rm -f ./rudder.conf
 
 veryclean:
 	rm -f ./rudder-sources.tar.bz2

--- a/rudder-reports/SPECS/rudder-reports.spec
+++ b/rudder-reports/SPECS/rudder-reports.spec
@@ -47,9 +47,8 @@ URL: http://www.rudder-project.org
 Group: Applications/System
 
 Source1: rudder-sources
-Source2: rudder.conf
-Source3: rudder-reports
-Source4: rudder-db
+Source2: rudder-reports
+Source3: rudder-db
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
@@ -95,13 +94,11 @@ rm -rf %{buildroot}
 # Directories
 mkdir -p %{buildroot}%{rudderdir}/etc/postgresql/
 mkdir -p %{buildroot}%{rudderdir}/etc/server-roles.d/
-mkdir -p %{buildroot}/etc/rsyslog.d
 
 cp %{SOURCE1}/rudder/rudder-core/src/main/resources/reportsSchema.sql %{buildroot}%{rudderdir}/etc/postgresql/
-cp -a %{SOURCE2} %{buildroot}/etc/rsyslog.d/rudder.conf
 
+install -m 644 %{SOURCE2} %{buildroot}/opt/rudder/etc/server-roles.d/
 install -m 644 %{SOURCE3} %{buildroot}/opt/rudder/etc/server-roles.d/
-install -m 644 %{SOURCE4} %{buildroot}/opt/rudder/etc/server-roles.d/
 
 %pre -n rudder-reports
 #=================================================
@@ -223,7 +220,6 @@ rm -rf %{buildroot}
 %defattr(-, root, root, 0755)
 %{rudderdir}/etc/postgresql/reportsSchema.sql
 %{rudderdir}/etc/server-roles.d/
-/etc/rsyslog.d/rudder.conf
 
 #=================================================
 # Changelog

--- a/rudder-reports/debian/rules
+++ b/rudder-reports/debian/rules
@@ -47,7 +47,6 @@ binary-arch: build install
 	dh_installchangelogs
 #	dh_installdocs
 	dh_install --sourcedir=$(CURDIR)/SOURCES/rudder-sources/rudder/rudder-core/src/main/resources/ reportsSchema.sql /opt/rudder/etc/postgresql/
-	dh_install --sourcedir=$(CURDIR)/SOURCES/ rudder.conf /etc/rsyslog.d/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-reports /opt/rudder/etc/server-roles.d/
 	dh_install --SOURCEDIR=$(CURDIR)/SOURCES/ rudder-db /opt/rudder/etc/server-roles.d/
 	dh_link


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8876