### PR TITLE
Fixes #8926: Agent sometimes fail to apply package actions because of global lock

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/27-fix-global-lock-package-promise.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/27-fix-global-lock-package-promise.patch
@@ -1,0 +1,119 @@
+From 23b0794f8c0b2a2e3d164fa4b1db2486b48fe89b Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@cfengine.com>
+Date: Fri, 19 Feb 2016 10:10:29 +0100
+Subject: [PATCH] Redmine #7933: Fix timing bug when grabbing global package
+ lock.
+
+Normally, when CFEngine grabs a promise lock, that exact lock is not
+expected to be grabbed again for the duration of the cf-agent run. And
+in fact, this is made impossible by the promise lock cache (see
+EvalContextPromiseLockCacheContains()). If a promise is in fact
+reevaluated, it is always because some part of the promise has
+changed, even something as simple as the promise comment. This alters
+the lock name, and hence it will count as a new lock. This behavior
+sometimes requires specific workarounds to rerun promises inside
+often-used bundles.
+
+However, the global package lock works a bit differently: Since we
+want to it to be a truly global lock, we need to reuse it. The first
+step in this process is to remove it from the promise lock cache. This
+is already done.
+
+However, we run into a subtle issue when it comes to `ifelapsed`
+values: `ifelapsed` is set to zero in the global package lock in order
+for timing not to get in the way. But the logic in locks.c to deal
+with ifelapsed is a bit flawed: The time counted as "now" is the start
+time of cf-agent, but the time recorded as "last time this lock was
+used" is the actual current time, which means that from the
+perspective of "now", the last used time of the lock may be in the
+future. This causes strange effects when cf-agent has been executing
+for more than a minute, `elapsedtime` inside `AcquireLock` turns
+negative, and this causes CFEngine to think that another agent is
+executing and it skips grabbing the lock altogether.
+
+And this is okay for locks with a nonzero ifelapsed value, since they
+are not generally expected to be executed more than once inside one
+cf-agent run, or when mutiple agents are executing in parallel, even
+if the value is 1, and that run takes longer than one minute.
+
+But for `ifelapsed == 0`, this check doesn't make sense because such
+locks should be grabbed regardless of whether it was grabbed before,
+or whether other agents have executed the same promise. Note that we
+are still protected against executing the same promise *at the same
+time*, this only introduces the capability to grab a promise lock that
+was executed earlier in the same run, or earlier by a different agent.
+
+Effects this has on the locks:
+
+* Executing the same promise concurrently:
+  NO (no change). You still cannot grab a currently held lock.
+
+* Executing the exact same promise twice in the same run:
+  NO (no change). If you got to the `elapsedtime` check this might
+  happen, but we never get there because the promise lock cache will
+  exit from the function early.
+
+* Executing the exact same promise in concurrent agents with
+  `ifelapsed >= 1`:
+  NO (no change). For `ifelapsed >= 0` the logic is unchanged.
+
+* Executing the exact same promise in concurrent agents with
+  `ifelapsed == 0`:
+  YES (CHANGED). This can now happen, since we don't check if another
+  agent has executed the promise. I believe this is perfectly okay and
+  even expected, since `ifelapsed == 0`.
+
+* Grabbing the exact same promise lock twice in the same run, if lock
+  is removed from promise lock cache and `ifelapsed == 0`:
+  YES (CHANGED). Currently *only* the global package lock does this,
+  and it is a requirement for it to work correctly. This case is what
+  the bugfix is about, the others are just possible side effects.
+
+Changelog: Fix a bug which sometimes caused package promises to be
+skipped with "XX Another cf-agent seems to have done this since I
+started" messages in the log, most notably in long running cf-agent
+runs (longer than one minute).
+---
+
+diff --git a/libpromises/locks.c b/libpromises/locks.c
+index 98e7b7b..cb71d45 100644
+--- a/libpromises/locks.c
++++ b/libpromises/locks.c
+@@ -709,20 +709,25 @@ CfLock AcquireLock(EvalContext *ctx, const char *operand, const char *host, time
+     time_t lastcompleted = FindLock(cflast);
+     time_t elapsedtime = (time_t) (now - lastcompleted) / 60;
+ 
+-    if (elapsedtime < 0)
++    // For promises/locks with ifelapsed == 0, skip all detection logic of
++    // previously acquired locks, whether in this agent or a parallel one.
++    if (tc.ifelapsed != 0)
+     {
+-        Log(LOG_LEVEL_VERBOSE, "XX Another cf-agent seems to have done this since I started (elapsed=%jd)",
+-              (intmax_t) elapsedtime);
+-        ReleaseCriticalSection(CF_CRITIAL_SECTION);
+-        return CfLockNull();
+-    }
++        if (elapsedtime < 0)
++        {
++            Log(LOG_LEVEL_VERBOSE, "XX Another cf-agent seems to have done this since I started (elapsed=%jd)",
++                (intmax_t) elapsedtime);
++            ReleaseCriticalSection(CF_CRITIAL_SECTION);
++            return CfLockNull();
++        }
+ 
+-    if (elapsedtime < tc.ifelapsed)
+-    {
+-        Log(LOG_LEVEL_VERBOSE, "XX Nothing promised here [%.40s] (%jd/%u minutes elapsed)", cflast,
+-              (intmax_t) elapsedtime, tc.ifelapsed);
+-        ReleaseCriticalSection(CF_CRITIAL_SECTION);
+-        return CfLockNull();
++        if (elapsedtime < tc.ifelapsed)
++        {
++            Log(LOG_LEVEL_VERBOSE, "XX Nothing promised here [%.40s] (%jd/%u minutes elapsed)", cflast,
++                (intmax_t) elapsedtime, tc.ifelapsed);
++            ReleaseCriticalSection(CF_CRITIAL_SECTION);
++            return CfLockNull();
++        }
+     }
+ 
+     // Look for existing (current) processes


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8926