### PR TITLE
Fixes #8718: Missing init script in rudder-agent package on Debian 7

### DIFF
--- a/rudder-agent/debian/install
+++ b/rudder-agent/debian/install
@@ -1,1 +1,4 @@
 opt/rudder
+etc
+usr/bin
+var/rudder


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8718