### PR TITLE
Fixes #8970: Debian packages are build with embedded openssl

### DIFF
--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -26,7 +26,7 @@ endif
 
 # add openssl to old distributions
 OS_CODENAME := $(shell lsb_release -s -c)
-ifneq (lucid,$(OS_CODENAME))
+ifeq (lucid,$(OS_CODENAME))
 USE_SYSTEM_OPENSSL=false
 endif
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8970