### PR TITLE
Fixes #9001: Made webapp's spec file build on SLES12

### DIFF
--- a/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
+++ b/ncf-api-virtualenv/SPECS/ncf-api-virtualenv.spec
@@ -47,7 +47,7 @@
 %endif
 
 ## SLES
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 %define apache_vhost_dir    /etc/apache2/conf.d
 %endif
 
@@ -94,7 +94,7 @@ Requires: policycoreutils-python
 %endif
 
 ## SLES
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 Requires: apache2 apache2-mod_wsgi pwdutils
 %endif
 
@@ -137,7 +137,7 @@ cp -f %{SOURCE3} %{_builddir}
 cd %{_sourcedir}
 
 # Build Virtualenv
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 # SLES specific exception, see http://www.rudder-project.org/redmine/issues/6365
 python virtualenv-1.10.1/virtualenv.py %{real_name}
 
@@ -232,7 +232,7 @@ fi
 # automatically, nothing to do here :)
 %endif
 
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 # Enable mod_wsgi using a2enmod
 a2enmod wsgi >/dev/null 2>&1
 

--- a/rudder-inventory-endpoint/SPECS/rudder-inventory-endpoint.spec
+++ b/rudder-inventory-endpoint/SPECS/rudder-inventory-endpoint.spec
@@ -37,7 +37,7 @@
 
 %define maven_settings settings-external.xml
 
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 %define syslogservicename syslog
 %endif
 
@@ -102,7 +102,7 @@ Requires: jetty-server
 
 ## 3 - SLES
 ## No Jetty provided by SLES... Use our own.
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 BuildRequires: jdk >= 1.7
 Requires: rudder-jetty = %{real_epoch}:%{real_version}
 %endif

--- a/rudder-inventory-ldap/SPECS/rudder-inventory-ldap.spec
+++ b/rudder-inventory-ldap/SPECS/rudder-inventory-ldap.spec
@@ -35,7 +35,7 @@
 %define ruddervardir     /var/rudder
 %define rudderlogdir     /var/log/rudder
 
-%if 0%{?sles_version} 
+%if 0%{?suse_version}
 %define syslogservicename syslog
 %endif
 
@@ -87,6 +87,12 @@ BuildRequires: openssl-devel
 %endif
 
 %if 0%{?sles_version} && 0%{?sles_version} == 11
+BuildRequires: libopenssl-devel
+%endif
+
+## See at: https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto
+## SLE 12 => %if 0%{?suse_version} == 1315 (but could also be Leap 42.1*)
+%if 0%{?suse_version} && 0%{?suse_version} == 1315
 BuildRequires: libopenssl-devel
 %endif
 

--- a/rudder-jetty/SPECS/rudder-jetty.spec
+++ b/rudder-jetty/SPECS/rudder-jetty.spec
@@ -39,7 +39,7 @@
 
 %define _binaries_in_noarch_packages_terminate_build   0
 
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 %define jetty_init_script jetty-sles.sh
 %else
 %define jetty_init_script jetty-rpm.sh

--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -146,7 +146,7 @@ service %{apache} stop > /dev/null && echo " Done"
 /bin/systemctl stop  %{apache}.service && echo " Done"
 %endif
 
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 # On SuSE, enable the required modules
 MODULES_TO_ENABLE="dav dav_fs version"
 

--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -39,7 +39,7 @@
 
 %define maven_settings settings-external.xml
 
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 %define apache                  apache2
 %define apache_tools            apache2-utils
 %define apache_group            www
@@ -143,7 +143,7 @@ Requires: jetty-server
 
 ## 3 - SLES
 ## No Jetty provided by SLES... Use our own.
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 BuildRequires: jdk >= 1.7
 Requires: rudder-jetty = %{real_epoch}:%{real_version}
 %endif
@@ -251,7 +251,7 @@ install -m 644 %{SOURCE2} %{buildroot}%{rudderdir}/share/webapps/
 cp %{SOURCE3} %{buildroot}%{rudderdir}/etc/
 cp %{SOURCE4} %{buildroot}%{rudderdir}/etc/
 
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 # On SLES, change the Apache DocumentRoot to the OS default
 sed -i "s%^DocumentRoot /var/www$%DocumentRoot /srv/www%" %{buildroot}%{rudderdir}/etc/rudder-apache-common.conf
 %endif
@@ -368,7 +368,7 @@ if ! getent group %{config_repository_group} | grep -q ncf-api-venv > /dev/null;
 fi
 
 # Add required includes in the SLES apache2 configuration
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 if ! grep -qE "^. /etc/sysconfig/rudder-apache$" /etc/sysconfig/apache2
 then
 	echo -e '# This sources the modules/defines needed by Rudder\n. /etc/sysconfig/rudder-apache' >> /etc/sysconfig/apache2
@@ -548,7 +548,7 @@ if [ $1 -eq 0 ]; then
     echo " Done"
   fi
 
-%if 0%{?sles_version}
+%if 0%{?suse_version}
   # Remove required includes in the SLES apache2 configuration
   if [ -f /etc/sysconfig/apache2 ]; then
     sed -i "/# This sources the modules\/defines needed by Rudder/d" /etc/sysconfig/apache2


### PR DESCRIPTION
Apparently SLES12 SP1+ has no more %{sles_release} as macro,
only %{suse_release}, which however is defined also on SLES11
systems.