### PR TITLE
Fixes #9082: Kept classes are not defined when editing fields in a file in warn only mode

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/36-define-kept-edit-line-warn.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/36-define-kept-edit-line-warn.patch
@@ -1,0 +1,154 @@
+From bb6a85f25d74551697eb28cb0917045619a9aa99 Mon Sep 17 00:00:00 2001
+From: Alexis Mousset <alexis.mousset@normation.com>
+Date: Wed, 6 Jul 2016 17:58:02 +0200
+Subject: [PATCH] CFE-2424: define kept outcome with action warn if edit_line
+ is as expected
+
+Changelog: Title
+(cherry picked from commit dbb44af5a0b8f8794d506683840675f43fe99dbf)
+---
+ cf-agent/files_edit.c                              |   2 +
+ .../08_field_edits/set_classes_in_warn_only.cf     | 121 +++++++++++++++++++++
+ 2 files changed, 123 insertions(+)
+ create mode 100644 tests/acceptance/10_files/08_field_edits/set_classes_in_warn_only.cf
+
+diff --git a/cf-agent/files_edit.c b/cf-agent/files_edit.c
+index c9d8159..238e596 100644
+--- a/cf-agent/files_edit.c
++++ b/cf-agent/files_edit.c
+@@ -115,6 +115,8 @@ void FinishEditContext(EvalContext *ctx, EditContext *ec, Attributes a, const Pr
+         }
+         else
+         {
++            cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a,
++                 "No edit changes to file '%s' need saving", ec->filename);
+             *result = PROMISE_RESULT_NOOP;
+         }
+     }
+diff --git a/tests/acceptance/10_files/08_field_edits/set_classes_in_warn_only.cf b/tests/acceptance/10_files/08_field_edits/set_classes_in_warn_only.cf
+new file mode 100644
+index 0000000..f77f084
+--- /dev/null
++++ b/tests/acceptance/10_files/08_field_edits/set_classes_in_warn_only.cf
+@@ -0,0 +1,121 @@
++#######################################################
++#
++#Tries to edit a file in warn_only, and must have a kept class defined 
++#
++#######################################################
++
++body common control
++{
++      inputs => { "../../default.cf.sub" };
++      bundlesequence  => { default("$(this.promise_filename)") };
++      version => "1.0";
++}
++
++#######################################################
++
++bundle agent init
++{
++  vars:
++      "filename_kept" string => "shadow.kept";
++      "filename_failed" string => "shadow.failed";
++
++      "content" string =>
++      "nicolas:$1$NoSH4e.u$U4uEzaOuC0tmQThtI3hj00:16988:0:99999:7:::";
++
++      "name" string =>
++      "nicolas";
++
++      "field_kept" string =>
++      "$1$NoSH4e.u$U4uEzaOuC0tmQThtI3hj00";
++
++      "field_failed" string =>
++      "bad";
++
++  files:
++      "$(G.testfile).$(init.filename_kept)"
++        create => "true",
++        edit_line => init_insert("$(init.content)"),
++        edit_defaults => init_empty;
++
++      "$(G.testfile).$(init.filename_failed)"
++        create => "true",
++        edit_line => init_insert("$(init.content)"),
++        edit_defaults => init_empty;
++}
++
++bundle edit_line init_insert(str)
++{
++  insert_lines:
++      "$(str)";
++}
++
++body edit_defaults init_empty
++{
++      empty_file_before_editing => "true";
++}
++
++#######################################################
++
++bundle agent test
++{
++  files:
++      "$(G.testfile).$(init.filename_kept)"
++        create        => "false",
++        edit_line     => test_set_user_field("${init.name}", 2, "${init.field_kept}"),
++        action        => test_warn_only,
++        classes       => test_classes_generic("test_result_kept");
++
++      "$(G.testfile).$(init.filename_failed)"
++        create        => "false",
++        edit_line     => test_set_user_field("${init.name}", 2, "${init.field_failed}"),
++        action        => test_warn_only,
++        classes       => test_classes_generic("test_result_failed");
++}
++
++bundle edit_line test_set_user_field(user,field,val)
++{
++  field_edits:
++      "$(user):.*"
++      comment => "Edit a user attribute in the password file",
++      edit_field => test_col(":","$(field)","$(val)","set");
++}
++
++body edit_field test_col(split,col,newval,method)
++{
++      field_separator    => "$(split)";
++      select_field       => "$(col)";
++      value_separator    => ",";
++      field_value        => "$(newval)";
++      field_operation    => "$(method)";
++      extend_fields      => "true";
++      allow_blank_fields => "true";
++}
++
++body action test_warn_only
++{
++      action_policy => "warn";
++      ifelapsed => "60";
++}
++
++body classes test_classes_generic(x)
++{
++      promise_repaired => { "$(x)_repaired" };
++      repair_failed => { "$(x)_failed" };
++      repair_denied => { "$(x)_denied" };
++      repair_timeout => { "$(x)_timeout" };
++      promise_kept => { "$(x)_ok" };
++}
++
++
++#######################################################
++
++bundle agent check
++{
++  reports:
++    test_result_kept_ok.test_result_failed_failed::
++      "$(this.promise_filename) Pass";
++
++    !(test_result_kept_ok.test_result_failed_failed)::
++      "$(this.promise_filename) FAIL";
++}
++


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9082