### PR TITLE
Fixes #9327: Error on inventory of policy servers:  Error when parsing an <RUDDER><AGENT> entry, that agent will be ignored. <- could not parse policy server id (tag POLICY_SERVER_UUID) from specific inventory

### DIFF
--- a/rudder-agent/SOURCES/patches/fusioninventory/0017-Fixes-3047-correct-Rudder-detection-on-Windows-and-d.patch
+++ b/rudder-agent/SOURCES/patches/fusioninventory/0017-Fixes-3047-correct-Rudder-detection-on-Windows-and-d.patch
@@ -106,7 +106,7 @@ index 0000000..4f963e7
 +	
 +    # Potential agent directory candidates
 +    my %agent_candidates = ( '/var/rudder/cfengine-community' => 'cfengine-community',
-+                             '/var/cfengine'                  => 'cfengine-nova',
++                             '/var/rudder/cfengine-nova'      => 'cfengine-nova',
 +                             'C:/Program Files/Cfengine'      => 'cfengine-nova',
 +                           );
 +


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9327