### PR TITLE
Fixes #9613: On Ubuntu 16.04, openjdk 9 is installed by default, and not recognized as a compatible version

### DIFF
--- a/rudder-jetty/debian/control
+++ b/rudder-jetty/debian/control
@@ -9,6 +9,7 @@ Homepage: http://www.rudder-project.org
 Package: rudder-jetty
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, sun-java6-jre (>=6) | java7-runtime-headless
+Conflicts: java9-runtime-headless, java9-runtime
 Description: Configuration management and audit tool - Jetty application server
  Rudder is an open source configuration management and audit solution.
  .


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9613