### PR TITLE
Fixes #9760: cfengine 3.10 doesn't build properly with a non system pcre

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/50-build-with-pcre.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/50-build-with-pcre.patch
@@ -1,0 +1,32 @@
+diff -ruN cfengine-source/cf-key/Makefile.am cfengine-source.new/cf-key/Makefile.am
+--- cfengine-source/cf-key/Makefile.am	2016-11-01 08:47:08.000000000 +0100
++++ cfengine-source.new/cf-key/Makefile.am	2016-12-01 16:24:37.521436465 +0100
+@@ -28,10 +28,12 @@
+ 	-I$(srcdir)/../libutils \
+ 	-I$(srcdir)/../libcfnet \
+ 	-I$(srcdir)/../libpromises \
++	$(PCRE_CPPFLAGS) \
+ 	$(ENTERPRISE_CPPFLAGS)
+ 
+ AM_CFLAGS = \
+ 	$(OPENSSL_CFLAGS) \
++	$(PCRE_CFLAGS) \
+ 	$(ENTERPRISE_CFLAGS)
+ 
+ libcf_key_la_SOURCES = \
+diff -ruN cfengine-source/cf-key/Makefile.in cfengine-source.new/cf-key/Makefile.in
+--- cfengine-source/cf-key/Makefile.in	2016-11-01 08:47:50.000000000 +0100
++++ cfengine-source.new/cf-key/Makefile.in	2016-12-01 16:25:02.017436542 +0100
+@@ -427,10 +427,12 @@
+ 	-I$(srcdir)/../libutils \
+ 	-I$(srcdir)/../libcfnet \
+ 	-I$(srcdir)/../libpromises \
++	$(PCRE_CPPFLAGS)
+ 	$(ENTERPRISE_CPPFLAGS)
+ 
+ AM_CFLAGS = \
+ 	$(OPENSSL_CFLAGS) \
++	$(PCRE_CFLAGS) \
+ 	$(ENTERPRISE_CFLAGS)
+ 
+ libcf_key_la_SOURCES = \


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9760