### PR TITLE
Fixes #9762: cfengine 3.10 doesn't build properly with a non system pcre

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/50-build-with-pcre.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/50-build-with-pcre.patch
@@ -21,7 +21,7 @@ diff -ruN cfengine-source/cf-key/Makefile.in cfengine-source.new/cf-key/Makefile
  	-I$(srcdir)/../libutils \
  	-I$(srcdir)/../libcfnet \
  	-I$(srcdir)/../libpromises \
-+	$(PCRE_CPPFLAGS)
++	$(PCRE_CPPFLAGS) \
  	$(ENTERPRISE_CPPFLAGS)
  
  AM_CFLAGS = \


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9762