### PR TITLE
Fixes #9744: No server inventory in web interface if /etc/hosts is not correctly configured

### DIFF
--- a/rudder-webapp/SOURCES/rudder-init
+++ b/rudder-webapp/SOURCES/rudder-init
@@ -183,6 +183,8 @@ function generate_promises_at_temporary_location() {
 
   cp -r /opt/rudder/share/initial-promises/ ${TMP_DIR}/community
 
+  [ -n "${COMPUTED_ALLOWED_NETWORKS}" ] && COMPUTED_ALLOWED_NETWORKS="${COMPUTED_ALLOWED_NETWORKS},"
+  COMPUTED_ALLOWED_NETWORKS=" ${COMPUTED_ALLOWED_NETWORKS} \"127.0.0.0/8\" , \"::1\" "
   find $TMP_DIR/community -name "cf-served.cf" -type f -exec sed -i "s@'%%POLICY_SERVER_ALLOWED_NETWORKS%%'@$COMPUTED_ALLOWED_NETWORKS@g" {} \;
 }
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9744

Replacing previous PR: https://github.com/Normation/rudder-packages/pull/1144
