### PR TITLE
Fixes #9818: Rudder's LDAP server configuration does not allow to query the monitor DB

### DIFF
--- a/rudder-inventory-ldap/SOURCES/slapd.conf
+++ b/rudder-inventory-ldap/SOURCES/slapd.conf
@@ -30,6 +30,10 @@ loglevel none
 access to dn.base="" by * read
 access to dn.base="cn=Subschema" by * read
 
+#       Allow access to monitor statistics by the rootdn of the main DB
+#       (this is a different DB, so not implicitly allowed)
+access to dn.subtree="cn=Monitor" by dn="cn=Manager,cn=rudder-configuration" read
+
 # No other access to the directory contents (except by the rootdn, but that is implicit)
 access to * by * none
 # ACLs - end
@@ -60,5 +64,6 @@ idlcachesize	300000
 index	objectClass	eq
 
 # 2 - Monitor
-
+# Query statistics here by running:
+#     ldapsearch -x -D "cn=Manager,cn=rudder-configuration" -w $(grep ^rootpw /opt/rudder/etc/openldap/slapd.conf | sed 's/^rootpw *//') -b 'cn=Monitor' -s sub '+'
 database monitor


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9818