### PR TITLE
Fixes #9828: The relay package must depend on python dev package to be able to build

### DIFF
--- a/rudder-server-relay/SOURCES/.dependencies
+++ b/rudder-server-relay/SOURCES/.dependencies
@@ -1,0 +1,8 @@
+SLES10:python-devel
+SLES11:python-devel
+SLES12:python-devel
+RHEL5:python-devel
+RHEL6:python-devel
+RHEL7:python-devel
+FEDORA18:python-devel
+FEDORA20:python-devel

--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -76,7 +76,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 # Requirements
 
 ## General
-BuildRequires: python
+BuildRequires: python, python-devel
 Requires: rudder-agent, rsyslog, openssl, %{apache}, %{apache_tools}, python
 
 ## RHEL

--- a/rudder-server-relay/debian/control
+++ b/rudder-server-relay/debian/control
@@ -2,7 +2,7 @@ Source: rudder-server-relay
 Section: web
 Priority: extra
 Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
-Build-Depends: debhelper (>= 7), python
+Build-Depends: debhelper (>= 7), python, libpython-dev
 Standards-Version: 3.8.0
 Homepage: http://www.rudder-project.org
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9828