### PR TITLE
Fixes #9838: Old debian call libpython-dev python-dev

### DIFF
--- a/rudder-server-relay/debian/control
+++ b/rudder-server-relay/debian/control
@@ -2,7 +2,7 @@ Source: rudder-server-relay
 Section: web
 Priority: extra
 Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
-Build-Depends: debhelper (>= 7), python, libpython-dev | libpython2.7-dev
+Build-Depends: debhelper (>= 7), python, libpython-dev | libpython2.7-dev | python2.7-dev
 Standards-Version: 3.8.0
 Homepage: http://www.rudder-project.org
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9838