### PR TITLE
Fixes #9851: ncf-api-virtualenv build depends on selinux

### DIFF
--- a/ncf-api-virtualenv/SOURCES/.dependencies
+++ b/ncf-api-virtualenv/SOURCES/.dependencies
@@ -3,7 +3,7 @@ SLES11:python
 SLES12:python
 RHEL3:python
 RHEL5:python
-RHEL6:python
-RHEL7:python
-FEDORA18:python
-FEDORA20:python
+RHEL6:python selinux-policy
+RHEL7:python selinux-policy-devel
+FEDORA18:python selinux-policy-devel
+FEDORA20:python selinux-policy-devel


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9851