### PR TITLE
Fixes #10072: On CentOS relay API uses /etc/httpd/logs/wsgi.18610.0.1.sock

### DIFF
--- a/rudder-server-relay/SOURCES/rudder-vhost.conf
+++ b/rudder-server-relay/SOURCES/rudder-vhost.conf
@@ -1,5 +1,6 @@
 # Set up a WSGI serving process common to ssl and non ssl vhost
 WSGIDaemonProcess relay_api threads=5 user=rudder
+WSGISocketPrefix /var/run/wsgi
 
 <VirtualHost *:80>
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10072