### PR TITLE
Fixes #10090: Missing selinux-policy-devel in rudder-server-relay dependencies

### DIFF
--- a/rudder-server-relay/SOURCES/.dependencies
+++ b/rudder-server-relay/SOURCES/.dependencies
@@ -1,0 +1,4 @@
+RHEL6:selinux-policy
+RHEL7:selinux-policy-devel
+FEDORA18:selinux-policy-devel
+FEDORA20:selinux-policy-devel


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10090