### PR TITLE
Fixes #10085: Download Shared from node and  to nodes fail because /var/rudder/share-files is non existent (on centos)

### DIFF
--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -194,6 +194,7 @@ mkdir -p %{buildroot}%{rudderdir}/etc/ssl/
 mkdir -p %{buildroot}%{rudderdir}/share/selinux/
 mkdir -p %{buildroot}%{ruddervardir}/inventories/incoming
 mkdir -p %{buildroot}%{ruddervardir}/inventories/accepted-nodes-updates
+mkdir -p %{buildroot}%{ruddervardir}/shared-files
 mkdir -p %{buildroot}%{rudderlogdir}/apache2/
 mkdir -p %{buildroot}/etc/sysconfig/
 mkdir -p %{buildroot}/etc/cron.d/
@@ -430,6 +431,7 @@ rm -rf %{buildroot}
 %attr(0440, root, root) %config /etc/sudoers.d/rudder-relay
 %{ruddervardir}/inventories/incoming
 %{ruddervardir}/inventories/accepted-nodes-updates
+%{ruddervardir}/shared-files/
 %{rudderlogdir}/apache2/
 %{rudderdir}/share/relay-api/
 

--- a/rudder-server-relay/debian/dirs
+++ b/rudder-server-relay/debian/dirs
@@ -3,5 +3,6 @@ opt/rudder/etc/ssl
 opt/rudder/share/relay-api
 var/rudder/inventories/accepted-nodes-updates
 var/rudder/inventories/incoming
+var/rudder/shared-files
 var/log/rudder/apache2
 etc/apache2/conf-available


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10085