### PR TITLE
Fixes #10190: Missing prefix in asynchronous output in remote run

### DIFF
--- a/rudder-server-relay/SOURCES/relay-api/relay_api/remote_run.py
+++ b/rudder-server-relay/SOURCES/relay-api/relay_api/remote_run.py
@@ -101,7 +101,7 @@ def run_command(command, prefix, keep_output, asynchronous):
     else:
       def stream():
         for line in iter(process.stdout.readline,''):
-          yield line.rstrip()+"\n"
+          yield prefix + ":" + line.rstrip()+"\n"
       output=stream()
   else:
     output = ""


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10190