### PR TITLE
Fixes #10334: make clean in rudder agent package doesn't remove build-cfengine-stamp

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -213,7 +213,7 @@ endif
 clean: localclean
 localclean:
 	rm -rf $(DESTDIR)
-	rm -rf build-ssl build-lmdb build-cfengine build-perl fusion-modules
+	rm -rf build-ssl build-lmdb build-cfengine build-perl fusion-modules build-cfengine-stamp
 	rm -rf rudder-sources
 	[ -d cfengine-source ] && cd cfengine-source && $(MAKE) clean 2>/dev/null || true
 	[ -d lmdb-source ] && cd lmdb-source && $(MAKE) clean 2>/dev/null || true


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10334