### PR TITLE
Fixes #10347: rpm does not build since packaging of /var/rudder/ncf dirs

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -139,6 +139,8 @@ install: build $(INSTALL_DEPS) install-cfengine initial-promises initial-ncf rud
 	chmod 700 $(DESTDIR)/var/rudder/cfengine-community/ppkeys
 	mkdir -p $(DESTDIR)/var/rudder/tmp
 	mkdir -p $(DESTDIR)/var/rudder/tools
+	mkdir -p $(DESTDIR)/var/rudder/ncf/local
+	mkdir -p $(DESTDIR)/var/rudder/ncf/common
 	mkdir -p $(DESTDIR)/var/log/rudder/install
 	mkdir -p $(DESTDIR)/usr/bin
 	mkdir -p $(DESTDIR)/etc/cron.d

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -464,7 +464,6 @@ rm -f %{_builddir}/file.list.%{name}
 %dir %{ruddervardir}/cfengine-community/bin
 %dir %{ruddervardir}/cfengine-community/inputs
 %dir %{ruddervardir}/tmp
-%dir %{ruddervardir}/ncf
 %dir %{ruddervardir}/ncf/common
 %dir %{ruddervardir}/ncf/local
 %dir %{ruddervardir}/tools


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10347