### PR TITLE
Fixes #10475: Empty output of service rudder restart on Debian 8

### DIFF
--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -43,7 +43,7 @@ case "$1" in
   chmod 755 -R /opt/rudder/share/tools
 
   echo -n "INFO: Restarting Apache HTTPd..."
-  /etc/init.d/apache2 restart >/dev/null 2>&1
+  service apache2 restart >/dev/null 2>&1
   echo " Done"
 
   # Run any upgrades


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10475