### PR TITLE
Fixes #10506: Rudder 4.1 fails to install Ubuntu/Debian because of rudder-slapd service restart

### DIFF
--- a/rudder-inventory-ldap/debian/postinst
+++ b/rudder-inventory-ldap/debian/postinst
@@ -65,6 +65,10 @@ case "$1" in
 					exit 1
 				fi
 
+        # Reload systemd when it is available so that it creates sysv-init shims
+        # This is necessary to make the service command work, and will be obsolete when we create systemd units
+        [ -x /bin/systemctl ] && /bin/systemctl daemon-reload
+
 				# Stop OpenLDAP - use forcestop to avoid the init script failing
 				# when trying to do the backup with bad libdb versions
 				echo -n "INFO: Stopping rudder-slapd..."

--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -140,6 +140,10 @@ case "$1" in
     /opt/ruder/bin/rudder-pkg restore-status < /tmp/rudder-plugins-upgrade
   fi
 
+  # Reload systemd when it is available so that it creates sysv-init shims
+  # This is necessary to make the service command work, and will be obsolete when we create systemd units
+  [ -x /bin/systemctl ] && /bin/systemctl daemon-reload
+
   # Restart the webapp
   echo -n "INFO: Restarting Rudder webapp and inventory-endpoint..."
   service rudder-jetty start >/dev/null 2>&1


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10506