### PR TITLE
Fixes #10514: Rudder 4.1 fails to install Ubuntu/Debian because of rudder-slapd service restart

### DIFF
--- a/rudder-inventory-ldap/debian/postinst
+++ b/rudder-inventory-ldap/debian/postinst
@@ -38,6 +38,11 @@ case "$1" in
                 # We need it to be able to open big mdb memory-mapped databases
                 ulimit -v unlimited
 
+                # Reload systemd when it is available so that it creates sysv-init shims
+                # This is necessary to make the service command work, and will be obsolete when we create systemd units
+                [ -x /bin/systemctl ] && /bin/systemctl daemon-reload
+
+
 		# Do we have a backup file from preinst
 		BACKUP_LDIF=$(find ${BACKUP_LDIF_PATH} -regextype sed -regex "${BACKUP_LDIF_REGEX}" 2>&1 | sort -nr | head -n1)
 		if [ -n "${BACKUP_LDIF}" ]; then
@@ -64,10 +69,6 @@ case "$1" in
 					echo >&2 "ERROR: No database backup for old version. Can't upgrade rudder-inventory-ldap database..."
 					exit 1
 				fi
-
-        # Reload systemd when it is available so that it creates sysv-init shims
-        # This is necessary to make the service command work, and will be obsolete when we create systemd units
-        [ -x /bin/systemctl ] && /bin/systemctl daemon-reload
 
 				# Stop OpenLDAP - use forcestop to avoid the init script failing
 				# when trying to do the backup with bad libdb versions


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10514