### PR TITLE
Fixes #10628: rudder-pkg error on debian8: missing depency to xz-utils

### DIFF
--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -94,7 +94,7 @@ AutoProv: 0
 
 ## General
 BuildRequires: python, python-devel
-Requires: rudder-agent >= %{real_epoch}:%{real_version}, rsyslog, openssl, %{apache}, %{apache_tools}, python, binutils
+Requires: rudder-agent >= %{real_epoch}:%{real_version}, rsyslog, openssl, %{apache}, %{apache_tools}, python, binutils, xz
 
 ## RHEL
 %if 0%{?rhel}

--- a/rudder-server-relay/debian/control
+++ b/rudder-server-relay/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.rudder-project.org
 
 Package: rudder-server-relay
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python, rudder-agent (>= ${binary:Version}), apache2, apache2-utils, rsyslog, openssl, libapache2-mod-wsgi, cron, binutils
+Depends: ${shlibs:Depends}, ${misc:Depends}, python, rudder-agent (>= ${binary:Version}), apache2, apache2-utils, rsyslog, openssl, libapache2-mod-wsgi, cron, binutils, xz-utils
 Description: Configuration management and audit tool - Server relay package
  Rudder is an open source configuration management and audit solution.
  .


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10628