### PR TITLE
Fixes #9905:  java.lang.InternalError when calling the internal API on Redhat because of invalid version of nss

### DIFF
--- a/rudder-jetty/SOURCES/Makefile
+++ b/rudder-jetty/SOURCES/Makefile
@@ -66,6 +66,7 @@ localdepends: ./jetty7
 
 	patch -p0 -s < patches/jetty/jetty-init-lsb-fix-debian.patch
 	patch -p0 -s < patches/jetty/jetty-init-lsb-fix-rpm.patch
+	patch -p0 -s < patches/jetty/jetty-init-softokn-version-check.patch
 
 	cp ./jetty7/bin/jetty-rpm.sh ./jetty7/bin/jetty-sles.sh
 	patch -p0 -s < patches/jetty/jetty-init-sles.patch

--- a/rudder-jetty/SOURCES/patches/jetty/jetty-init-softokn-version-check.patch
+++ b/rudder-jetty/SOURCES/patches/jetty/jetty-init-softokn-version-check.patch
@@ -1,0 +1,18 @@
+diff -ruN jetty7/bin/jetty-rpm.sh jetty7.new/bin/jetty-rpm.sh
+--- jetty7/bin/jetty-rpm.sh	2017-04-25 11:22:09.988181290 +0200
++++ jetty7.new/bin/jetty-rpm.sh	2017-04-25 11:28:08.012174878 +0200
+@@ -483,6 +483,14 @@
+     UMASK="0007"
+     echo "Setting umask to ${UMASK}"
+ 
++    # Check if there is a mismatch in nss version, see http://www.rudder-project.org/redmine/issues/9905
++    nss_ver=$(rpm -qa nss | cut -d - -f 2)
++    softokn_ver=$(rpm -qa nss-softokn | cut -d - -f 3)
++    if [ "${nss_ver}" != "${softokn_ver}" ]
++    then
++      echo "nss version mismatch, your nss-softokn version (${softokn_ver}) should match your nss version (${nss_ver})"
++      exit 1
++    fi
+     # Checking if enough RAM is available for Jetty to use
+     checkAvailableRam $((${JAVA_XMX}+${JAVA_MAXPERMSIZE}))
+ 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9905