### PR TITLE
Fixes #10493: If cf-serverd is not up, hook 50-reload-policy-file-server is in error and breaks policy generation

### DIFF
--- a/rudder-webapp/SOURCES/rudder-reload-cf-serverd
+++ b/rudder-webapp/SOURCES/rudder-reload-cf-serverd
@@ -1,8 +1,14 @@
 #!/bin/sh
 
 # Search for killall first
-if which killall; then
+if which killall >/dev/null 2>&1; then
   killall -1 cf-serverd
 else # No killall, use kill/pidof instead
   kill -1 $(pidof cf-serverd 2>/dev/null)
+fi
+
+# If reload failed, cf-serverd is stopped
+# Trying to restart
+if [ $? -ne 0 ]; then
+  service rudder-agent restart
 fi


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10493