### PR TITLE
Fixes #11015: Use port 514 for rsyslog on Ubuntu >= 14.04

### DIFF
--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -124,17 +124,6 @@ case "$1" in
 
   
   RUDDER_WEB_PROPERTIES="/opt/rudder/etc/rudder-web.properties"
-	# Only for Ubuntu:
-	## Change rsyslog port number since Ubuntu 12.04 doesn't allow to use standard
-	## rsyslog port number (https://bugs.launchpad.net/ubuntu/+source/rsyslog/+bug/789174)
-	CHECK_DIST=`/usr/bin/lsb_release -is`
-	CHECK_UBUNTU_VERSION=`/usr/bin/lsb_release -rs | cut -d. -f1`
-	CHECK_RSYSLOG_PORT=`grep -E "^rudder.syslog.port\s*=\s*[0-9]+\s*$" /opt/rudder/etc/rudder-web.properties | cut -d "=" -f2`
-	if [ "z${CHECK_DIST}" = "zUbuntu" -a ${CHECK_UBUNTU_VERSION} -ge 12 -a ${CHECK_RSYSLOG_PORT} -lt 1024 ]; then
-		echo "INFO: Since Ubuntu 12.04, rsyslog port number used by Rudder needs to be >1024"
-		sed -i "s/^rudder.syslog.port\w*=.*$/rudder.syslog.port=5514/" "${RUDDER_WEB_PROPERTIES}"
-		echo "INFO: rsyslog port number changed to 5514"
-	fi
 
   # Create a symlink to the Jetty context if necessary
   if [ -d "/opt/rudder/jetty7/contexts" ]; then


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11015