### PR TITLE
Fixes #11628: Error at installation of Rudder 4.1 on centos 6

### DIFF
--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -101,6 +101,14 @@ Requires: rudder-agent >= %{real_epoch}:%{real_version}, rsyslog, openssl, %{apa
 Requires: mod_ssl
 %endif
 
+%if 0%{?rhel} && 0%{?rhel} == 6
+Requires: python-argparse
+%endif
+
+%if 0%{?suse_version} && 0%{?suse_version} < 1200
+Requires: python-argparse
+%endif
+
 ## RHEL & Fedora
 %if 0%{?rhel} || 0%{?fedora}
 Requires: mod_wsgi shadow-utils crontabs


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11628