### PR TITLE
Fixes #11724: cf-* coredumps if policy_server.dat contains empty lines

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/11724-fix-segfault-empty-policy-server-dat.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/11724-fix-segfault-empty-policy-server-dat.patch
@@ -1,0 +1,29 @@
+From 88ae79b0e1a3ff3b94f2a668b2fc8a0c3fdd6288 Mon Sep 17 00:00:00 2001
+From: Alexis Mousset <alexis.mousset@normation.com>
+Date: Wed, 29 Nov 2017 10:56:55 +0100
+Subject: [PATCH] Do not segfault if policy_server.dat only contains
+ whitespaces and/or line breaks
+
+Changelog: Title
+---
+ libpromises/bootstrap.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/libpromises/bootstrap.c b/libpromises/bootstrap.c
+index d7c850a371..79e5da4567 100644
+--- a/libpromises/bootstrap.c
++++ b/libpromises/bootstrap.c
+@@ -219,6 +219,13 @@ bool ParsePolicyServerFile(const char *workdir, char **host, char **port)
+     (*port) = NULL;
+ 
+     ParseHostPort(contents, host, port);
++
++    // The file did not contain a host
++    if (*host == NULL)
++    {
++        return false;
++    }
++
+     (*host) = xstrdup(*host);
+     if (*port != NULL)
+     {


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11724