### PR TITLE
Fixes #11988: Wrong log folder for jetty on Debian 9 for Rudder 4.3

### DIFF
--- a/rudder-jetty/SOURCES/rudder-jetty-base/start.ini
+++ b/rudder-jetty/SOURCES/rudder-jetty-base/start.ini
@@ -221,14 +221,14 @@
 # Module: requestlog
 # Enables a NCSA style request log.
 # --------------------------------------- 
---module=requestlog
+#--module=requestlog
 
 ## Logging directory (relative to $jetty.base)
 # jetty.requestlog.dir=logs
 
 ## File path
 # jetty.requestlog.filePath=${jetty.requestlog.dir}/yyyy_mm_dd.request.log
- jetty.requestlog.filePath=/var/log/rudder/webapp/yyyy_mm_dd.request.log
+# jetty.requestlog.filePath=/var/log/rudder/webapp/yyyy_mm_dd.request.log
 
 ## Date format for rollovered files (uses SimpleDateFormat syntax)
 # jetty.requestlog.filenameDateFormat=yyyy_MM_dd


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11988