### PR TITLE
Fixes #12056: rudder-server-root-postinst is still not packaged on debian packages

### DIFF
--- a/rudder-server-root/debian/dirs
+++ b/rudder-server-root/debian/dirs
@@ -1,3 +1,4 @@
+opt/rudder
 opt/rudder/etc
 opt/rudder/bin
-
+opt/rudder/share


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12056