### PR TITLE
Fixes #12057: rudder-server-root-postinst is still not packaged on debian packages

### DIFF
--- a/rudder-server-root/debian/dirs
+++ b/rudder-server-root/debian/dirs
@@ -1,4 +1,3 @@
 opt/rudder
 opt/rudder/etc
 opt/rudder/bin
-opt/rudder/share

--- a/rudder-server-root/debian/rules
+++ b/rudder-server-root/debian/rules
@@ -41,6 +41,7 @@ binary-indep: install
 binary-arch: install
 	dh_testdir
 	dh_testroot
+	dh_install
 	dh_installchangelogs
 #	dh_installdocs
 #	dh_installexamples


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12057