### PR TITLE
Fixes #12061: Build error when building debian packages, missing var/rudder

### DIFF
--- a/rudder-server-root/debian/install
+++ b/rudder-server-root/debian/install
@@ -1,3 +1,2 @@
 opt/rudder
 etc
-var/rudder


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12061