### PR TITLE
Fixes #12328: rudder-jetty should depend on headless jre on centos7

### DIFF
--- a/rudder-jetty/SPECS/rudder-jetty.spec
+++ b/rudder-jetty/SPECS/rudder-jetty.spec
@@ -81,7 +81,7 @@ BuildArch: noarch
 # in RPM yet...
 
 %if 0%{?rhel} && 0%{?rhel} > 6
-Requires: jre >= 1.8
+Requires: jre-headless >= 1.8
 %endif
 
 %if 0%{?rhel} && 0%{?rhel} == 6


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12328