### PR TITLE
Fixes #12461: Problem: nothing provides libyaml needed by rudder-agent-1398866025:4.3.0.rc3-1.SLES.12.x86_64

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -239,7 +239,11 @@ BuildRequires: libattr-devel
 ## YAML dependencies
 %if "%{use_system_yaml}" == "true"
 BuildRequires: libyaml-devel
+%if 0%{?suse_version} && 0%{?suse_version} >= 1200
+Requires: libyaml-0-2
+%else
 Requires: libyaml
+%endif
 %endif
 
 ## XML dependencies


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12461