### PR TITLE
Fixes #12607: Webapp log file have been renamed from stderrout.log to jetty.log

### DIFF
--- a/rudder-jetty/SOURCES/Makefile
+++ b/rudder-jetty/SOURCES/Makefile
@@ -68,6 +68,9 @@ localdepends: ./jetty
 	cp ./rudder-jetty.default ../debian/rudder-jetty.default
 	chmod +x ../debian/rudder-jetty.init
 
+	# Restore the name for log file from version of Rudder before 4.3 (see https://www.rudder-project.org/redmine/issues/12607)
+	patch -p0 -s < patches/jetty/jetty-console-capture-restore-log-filename.patch
+
 	# Make sure there were no rejects
 	test `$(FIND) . -name \*.rej | wc -l` = 0
 

--- a/rudder-jetty/SOURCES/patches/jetty/jetty-console-capture-restore-log-filename.patch
+++ b/rudder-jetty/SOURCES/patches/jetty/jetty-console-capture-restore-log-filename.patch
@@ -1,0 +1,12 @@
+--- jetty/etc/console-capture.xml
++++ jetty/etc/console-capture.xml
+@@ -5,7 +5,7 @@
+     <New id="ServerLog" class="java.io.PrintStream">
+       <Arg>
+         <New class="org.eclipse.jetty.util.RolloverFileOutputStream">
+-          <Arg><Property name="jetty.console-capture.dir" deprecated="jetty.logging.dir" default="./logs"/>/yyyy_mm_dd.jetty.log</Arg>
++          <Arg><Property name="jetty.console-capture.dir" deprecated="jetty.logging.dir" default="./logs"/>/yyyy_mm_dd.stderrout.log</Arg>
+           <Arg type="boolean"><Property name="jetty.console-capture.append" deprecated="jetty.logging.append" default="false"/></Arg>
+           <Arg type="int"><Property name="jetty.console-capture.retainDays" deprecated="jetty.logging.retainDays" default="90"/></Arg>
+           <Arg>
+-- 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12607