### PR TITLE
Fixes #12757: Webapp log file have been renamed from stderrout.log to jetty.log

### DIFF
--- a/rudder-jetty/SOURCES/rudder-jetty-base/etc/console-capture.xml
+++ b/rudder-jetty/SOURCES/rudder-jetty-base/etc/console-capture.xml
@@ -5,7 +5,7 @@
     <New id="ServerLog" class="java.io.PrintStream">
       <Arg>
         <New class="org.eclipse.jetty.util.RolloverFileOutputStream">
-          <Arg><Property name="jetty.console-capture.dir" deprecated="jetty.logging.dir" default="/var/log/rudder/webapp"/>/yyyy_mm_dd.jetty.log</Arg>
+          <Arg><Property name="jetty.console-capture.dir" deprecated="jetty.logging.dir" default="/var/log/rudder/webapp"/>/yyyy_mm_dd.stderrout.log</Arg>
           <Arg type="boolean"><Property name="jetty.console-capture.append" deprecated="jetty.logging.append" default="false"/></Arg>
           <Arg type="int"><Property name="jetty.console-capture.retainDays" deprecated="jetty.logging.retainDays" default="90"/></Arg>
           <Arg>


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12757