### PR TITLE
Fixes #12698: rudder-agent 4.3 install hangs on Debian 7

### DIFF
--- a/rudder-agent/SOURCES/rudder-agent-postinst
+++ b/rudder-agent/SOURCES/rudder-agent-postinst
@@ -9,6 +9,12 @@ CFE_DIR="/var/rudder/cfengine-community"
 RUDDER_CMD="/opt/rudder/bin/rudder"
 LOG_FILE="/var/log/rudder/install/rudder-agent.log"
 
+# Closing all parents fd which are inherited, otherwise it can lead to
+# a postint unable to terminate (revelant at least on debian 7)
+for fd in $(ls /proc/self/fd); do
+  [ "${fd}" -gt 2 ] && eval "exec $fd>&-"
+done
+
 if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]
 then
   echo "Usage: $0 <CFRUDDER_FIRST_INSTALL> <CFRUDDER_OS> <CFRUDDER_USE_SYSTEMD>"


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12698