### PR TITLE
Fixes #12930: During an upgrade of Rudder, if a new generic method appears in ncf, that is also on local method, all is broken

### DIFF
--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -364,6 +364,26 @@ upgrade_ncf() {
     chmod -R o-rwx ${CONFIGURATION_REPOSITORY}/ncf/50_techniques/
   fi
 
+  # Handle the case where we have an existing local method and a common method with the same name
+  # Display a warning and delete local method
+  if [ -x ${CONFIGURATION_REPOSITORY}/ncf/30_generic_methods ]; then
+    cd "${CONFIGURATION_REPOSITORY}/ncf/30_generic_methods/"
+    commit_needed=0
+    for method in *.cf
+    do
+      [ -f "${method}" ] || break
+      if [ -f "${RUDDER_NCF_SOURCE_DIRECTORY}/tree/30_generic_methods/${method}" ]; then
+        if git rm "${method}"; then
+          commit_needed=1
+          echo "WARNING: The ${method} generic method was already present in local configuration, removing it."
+        else
+          mv "${method}" "${method}.disabled"
+          echo "WARNING: The ${method} generic method was already present in local configuration and not in local repo, disabling it (renamed to ${method}.disabled)."
+        fi
+      fi
+    done
+    [ "${commit_needed}" = "1" ] && git commit --allow-empty -q -m "Remove duplicate local methods - automatically done by rudder-upgrade script"
+  fi
 }
 
 # 3.2.0: Call rudderify on all local ncf techniques to make sure the promises will be properly generated


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12930