### PR TITLE
Fixes #12994: Missing lib path in AIX cfengine executables

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -514,7 +514,7 @@ rudder-agent.cron: rudder-sources
 ####################################
 
 # build flags should be used everywhere
-BUILD_FLAGS=CFLAGS="$(BUILD_CFLAGS) $(SECURE_CFLAGS)" LDFLAGS="-Wl,-R$(RUDDER_DIR)/lib $(BUILD_LDFLAGS) $(SECURE_LDFLAGS)"
+BUILD_FLAGS=CFLAGS="$(BUILD_CFLAGS) $(SECURE_CFLAGS)" LDFLAGS="$(BUILD_LDFLAGS) $(SECURE_LDFLAGS)"
 
 build-ssl: openssl-source
 	# openssl doesn't support CFLAGS (it overrides its own) so we must pass them in batch to configure
@@ -586,8 +586,6 @@ build-cfengine-stamp:
 
 # Test if compiler supports hardening flags
 get-flags:
-	$(eval BUILD_CFLAGS:=$(shell [ -x /usr/bin/dpkg-buildflags ] && /usr/bin/dpkg-buildflags --get CFLAGS ))
-	$(eval BUILD_LDFLAGS:=$(shell [ -x /usr/bin/dpkg-buildflags ] && /usr/bin/dpkg-buildflags --get LDFLAGS ))
 	$(eval HAVE_PROTECTION:=$(shell \
 	FLAG_TEST_FILE=`mktemp /tmp/hardening.XXXXXX` ;\
 	echo "void main() {}" > "$${FLAG_TEST_FILE}.c" ;\

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -280,9 +280,12 @@ Requires: pcre
 %if "%{?_os}" == "aix"
 %define install_command        installbsd -c
 %define cp_a_command           cp -hpPr
-%define build_ldflags -Wl,-brtl
+# -brtl forces libtool to use shared libraries
+# -L adds the library path to the produced executables
+# -static-libgcc is added because gcc is not provided on aix
+%define build_ldflags -static-libgcc -Wl,-brtl -Wl,-L%{rudderdir}/lib
 %else
-%define build_ldflags %{nil}
+%define build_ldflags -Wl,-R%{rudderdir}/lib
 %endif
 
 %if "%{real_name}" == "rudder-agent"

--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -12,6 +12,9 @@
 
 REAL_NAME=rudder-agent
 
+BUILD_CFLAGS=$(shell [ -x /usr/bin/dpkg-buildflags ] && /usr/bin/dpkg-buildflags --get CFLAGS )
+BUILD_LDFLAGS=$(shell [ -x /usr/bin/dpkg-buildflags ] && /usr/bin/dpkg-buildflags --get LDFLAGS ) -Wl,-R/opt/rudder/lib
+
 USE_SYSTEM_OPENSSL=true
 USE_SYSTEM_PERL=true
 USE_SYSTEM_CURL=true
@@ -102,7 +105,7 @@ configure:
 
 build:
 	dh_testdir
-	cd SOURCES && $(MAKE) build $(MAKE_OPTIONS)
+	cd SOURCES && $(MAKE) build $(MAKE_OPTIONS) BUILD_CFLAGS="$(BUILD_CFLAGS)" BUILD_LDFLAGS="$(BUILD_LDFLAGS)"
 
 clean:
 	dh_testdir
@@ -114,7 +117,7 @@ install: build
 	dh_testdir
 	dh_testroot
 	dh_installdirs
-	cd SOURCES && $(MAKE) install $(MAKE_OPTIONS) DESTDIR=$(CURDIR)/debian/tmp
+	cd SOURCES && $(MAKE) install $(MAKE_OPTIONS) BUILD_LDFLAGS="$(BUILD_LDFLAGS)" DESTDIR=$(CURDIR)/debian/tmp
 	# remove perl doc
 	rm -rf $(CURDIR)/debian/tmp/opt/rudder/man $(CURDIR)/debian/tmp/opt/rudder/lib/perl5/5.22.0/pod
 	# let this file be managed by dh_installinit


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12994