### PR TITLE
Fixes #10646: Error at the end of generation after accepting 500 nodes

### DIFF
--- a/rudder-inventory-ldap/SOURCES/rudder-inventory-ldap.default
+++ b/rudder-inventory-ldap/SOURCES/rudder-inventory-ldap.default
@@ -19,3 +19,7 @@
 # - "noauto" : Leave the setting alone
 #
 #RUDDER_MDBSIZE="auto" 
+
+# Specify the maximum incoming LDAP PDU size for authenticated sessions. The default is 4194303.
+# This is too little for Rudder usage, as there is some big entries (like Nodes Configuration)
+RUDDER_MAX_INCOMING_AUTH=1000000000

--- a/rudder-inventory-ldap/SOURCES/rudder-slapd-configure
+++ b/rudder-inventory-ldap/SOURCES/rudder-slapd-configure
@@ -1,11 +1,12 @@
 #!/bin/sh
 
-# Configure maxsize in /opt/rudder/etc/openldap/slapd.conf based on
+# Configure maxsize and sockbuf_max_incoming_auth in /opt/rudder/etc/openldap/slapd.conf based on
 # content of /etc/default/rudder-slapd, or auto-computed based on available memory
 
 # Script specific
 PROG_NAME='rudder-slapd'
 OS=`uname -s`   # To adapt message printing
+SLAPD_CONF_FILE=/opt/rudder/etc/openldap/slapd.conf
 
 
 #====================================================================
@@ -57,7 +58,18 @@ then
     # set cache size to the value provided
     MDBSIZE=${RUDDER_MDBSIZE}
   fi
-  sed -i '/^[ \t]*\(maxsize\|maxsize\)/d' /opt/rudder/etc/openldap/slapd.conf
-  sed -i 's/^\([ \t]*suffix[ \t]\+"cn=rudder-configuration".*\)/\1\nmaxsize '${MDBSIZE}'/' /opt/rudder/etc/openldap/slapd.conf
+  sed -i '/^[ \t]*maxsize/d' ${SLAPD_CONF_FILE}
+  sed -i 's/^\([ \t]*suffix[ \t]\+"cn=rudder-configuration".*\)/\1\nmaxsize '${MDBSIZE}'/' ${SLAPD_CONF_FILE}
 fi
+
+if [ "${RUDDER_MAX_INCOMING_AUTH}" != "" ]
+then
+    # Set value to the one in etc/default
+    MAX_INCOMING_AUTH=${RUDDER_MAX_INCOMING_AUTH}
+else
+    # 1000000000 as default max size fo incoming query
+    MAX_INCOMING_AUTH=1000000000
+fi
+sed -i '/^[ \t]*sockbuf_max_incoming_auth/d' ${SLAPD_CONF_FILE}
+sed -i 's/^\([ \t]*argsfile[ \t]\+\/.*\)/\1\nsockbuf_max_incoming_auth '${MAX_INCOMING_AUTH}'/' ${SLAPD_CONF_FILE}
 

--- a/rudder-inventory-ldap/SOURCES/slapd.conf
+++ b/rudder-inventory-ldap/SOURCES/slapd.conf
@@ -18,6 +18,11 @@ moduleload	back_monitor.la
 pidfile		/var/rudder/run/slapd.pid
 argsfile	/var/rudder/run/slapd.args
 
+
+# Specify the maximum incoming LDAP PDU size for authenticated sessions. The default is 4194303.
+# This is too little for Rudder, as there are some big entries (like Nodes Configuration)
+sockbuf_max_incoming_auth 1000000000
+
 # OpenLDAP loglevel
 # none means "Important messages"
 # stats provides details for each and every operation (verbose)


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10646

Testing that: 
- a fresh 4.1/4.3 install must have "sockbuf_max_incoming_auth" defined in /opt/rudder/etc/openldap/slapd.conf
- a migration from versions before the one with that correction towards one with it must also have the parameter defined. 