### PR TITLE
Purge of rudder-webapp should not fail

### DIFF
--- a/rudder-webapp/debian/postrm
+++ b/rudder-webapp/debian/postrm
@@ -21,12 +21,16 @@ set -e
 
 case "$1" in
     purge)
+      # ignore errors during purge
+      set +e
+      userdel rudder || true
       if getent group rudder > /dev/null; then
         # Remove the configuration-repository group
         echo -n "INFO: Removing group rudder..."
         groupdel rudder
         echo " Done"
       fi
+      set -e
     ;;
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     ;;


### PR DESCRIPTION
Fixed the purge of package rudder-webapp which had the following issues:

- user rudder was left on the system
- attempt to delete group 'rudder' failed as a user (rudder) was still using it