### PR TITLE
Fixes #13594: Debian package cannot build in 4.1 because of docs.rudder.io

### DIFF
--- a/rudder-agent/debian/control
+++ b/rudder-agent/debian/control
@@ -2,7 +2,7 @@ Source: rudder-agent
 Section: admin
 Priority: extra
 Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
-Build-Depends: debhelper (>= 7), libssl-dev, bison, gcc, flex, autoconf, automake, libtool, libpcre3-dev, libpam0g-dev, lsb-release
+Build-Depends: debhelper (>= 7), libssl-dev, bison, gcc, flex, autoconf, automake, libtool, libpcre3-dev, libpam0g-dev, lsb-release, ca-certificates
 Standards-Version: 3.8.0
 Homepage: http://www.rudder-project.org
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13594