### PR TITLE
Fixes #13664: Mustache templating in audit mode always considers destination compliant once it exists

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/13664-fix-class-dry-run-mustache.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/13664-fix-class-dry-run-mustache.patch
@@ -1,0 +1,56 @@
+From 2a0b7adca63ac5920adc42b6b818c9538747398a Mon Sep 17 00:00:00 2001
+From: Alexis Mousset <alexis.mousset@normation.com>
+Date: Mon, 15 Oct 2018 18:27:10 +0200
+Subject: [PATCH] CFE-2600: Fixed missing class with mustache templates in
+ warn_only mode
+
+The outcome classes were not defined when rendering a mustache template
+in warn_only mode.
+---
+ cf-agent/verify_files.c                                  | 4 +++-
+ tests/acceptance/10_files/mustache_respects_warn_only.cf | 8 +++++---
+ 2 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/cf-agent/verify_files.c b/cf-agent/verify_files.c
+index 84ea301d4..f44d8da82 100644
+--- a/cf-agent/verify_files.c
++++ b/cf-agent/verify_files.c
+@@ -620,7 +620,9 @@ static PromiseResult RenderTemplateMustache(EvalContext *ctx, const Promise *pp,
+         {
+             if (a.transaction.action == cfa_warn || DONTDO)
+             {
+-                Log(LOG_LEVEL_WARNING, "Need to render '%s' from mustache template '%s' but policy is dry-run", pp->promiser, a.edit_template);
++                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a, 
++                     "Need to update rendering of '%s' from mustache template '%s' but policy is dry-run",
++                     pp->promiser, a.edit_template);
+                 result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
+             }
+             else
+diff --git a/tests/acceptance/10_files/mustache_respects_warn_only.cf b/tests/acceptance/10_files/mustache_respects_warn_only.cf
+index eaa9b08544..3fe37dc238 100644
+--- a/tests/acceptance/10_files/mustache_respects_warn_only.cf
++++ b/tests/acceptance/10_files/mustache_respects_warn_only.cf
+@@ -39,7 +39,8 @@ bundle agent test
+     "$(template_target)"
+       edit_template => "$(this.promise_filename).mustache",
+       template_method => "mustache",
+-      action => warn_only;
++      action => warn_only,
++      classes => classes_generic("mustache_warn");
+ }
+ 
+ #######################################################
+@@ -48,10 +49,11 @@ bundle agent check
+ {
+   classes:
+     "fail" expression => regline("SHOULD NOT RENDER", $(test.template_target) );
++    "defined_class" expression => "mustache_warn_failed";
+ 
+   reports:
+-    !fail::
++    !fail.defined_class::
+       "$(this.promise_filename) Pass";
+-    fail::
++    fail|!defined_class::
+       "$(this.promise_filename) FAIL";
+ }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13664