### PR TITLE
Fixes #13670: Script rudder-support-info is too chatty when looking for time (branch 5.0)

### DIFF
--- a/rudder-agent/SOURCES/debug-script/lib/cfengineutils
+++ b/rudder-agent/SOURCES/debug-script/lib/cfengineutils
@@ -2,7 +2,7 @@
 
 cfengineutils_test_cfpromises() {
   # First we need to make sure time is there
-  TIME_PRESENT=`which time`
+  TIME_PRESENT=`which time > /dev/null 2>&1`
 
   if [ ${?} -eq 0 ]
   then


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13670