### PR TITLE
Fixes #13774: rudder-cf-execd and rudder-cf-serverd are not enabled nor running after a server install on debian 8

### DIFF
--- a/rudder-agent/debian/postinst
+++ b/rudder-agent/debian/postinst
@@ -36,7 +36,7 @@ case "$1" in
 
     CFRUDDER_USE_SYSTEMD="false"
 
-    if grep -q systemd /proc/1/cmdline > /dev/null ; then CFRUDDER_USE_SYSTEMD="true"; fi
+    if readlink -f $(cut -f 1 -d "" < /proc/1/cmdline) | grep -qE "/systemd$" ; then CFRUDDER_USE_SYSTEMD="true"; fi
     db_get rudder-agent/policy-server && server="${RET}"
 
     /opt/rudder/share/package-scripts/rudder-agent-postinst "${CFRUDDER_FIRST_INSTALL}" "deb" "${CFRUDDER_USE_SYSTEMD}" "${server}"

--- a/rudder-agent/debian/postrm
+++ b/rudder-agent/debian/postrm
@@ -31,7 +31,7 @@ case "$1" in
 
     CFRUDDER_USE_SYSTEMD="false"
 
-    if grep -q systemd /proc/1/cmdline > /dev/null ; then CFRUDDER_USE_SYSTEMD="true"; fi
+    if readlink -f $(cut -f 1 -d "" < /proc/1/cmdline) | grep -qE "/systemd$" ; then CFRUDDER_USE_SYSTEMD="true"; fi
 
 if [ CFRUDDER_USE_SYSTEMD="true" ]; then
   systemctl stop rudder-agent || true

--- a/rudder-agent/debian/preinst
+++ b/rudder-agent/debian/preinst
@@ -17,7 +17,7 @@ set -e
 CFRUDDER_FIRST_INSTALL=0
 CFRUDDER_USE_SYSTEMD=0
 
-if grep -q systemd /proc/1/cmdline > /dev/null ; then CFRUDDER_USE_SYSTEMD=1; fi
+if readlink -f $(cut -f 1 -d "" < /proc/1/cmdline) | grep -qE "/systemd$" ; then CFRUDDER_USE_SYSTEMD=1; fi
 
 case "$1" in
     install)


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13774