### PR TITLE
Fixes #13785: rudder-pkg enable-all fails when a plugin has no jar

### DIFF
--- a/rudder-server-relay/SOURCES/rudder-pkg
+++ b/rudder-server-relay/SOURCES/rudder-pkg
@@ -373,8 +373,9 @@ def plugin_status(plugins, status):
     if plugin not in DB["plugins"]:
       fail("Unknown plugin " + plugin)
     metadata = DB["plugins"][plugin]
-    for j in metadata['jar-files']:
-      jar_status(j, status)
+    if 'jar-files' in metadata:
+      for j in metadata['jar-files']:
+        jar_status(j, status)
 
 
 ## MAIN


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13785