### PR TITLE
Fixes #13770: There are still tables expectedreports & expectesreportsnodes on upgraded Rudder 4.x and 5.x,

### DIFF
--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -50,6 +50,7 @@ trap anomaly_handler ERR INT TERM
 # - 4.2.0        : Rename hooks to have a better ordering of hooks
 # - 4.2.4, 4.3.0 : Remove 90-reload hook since logic was integrated to Rudder in #11749
 # - 4.3          : Update ncf Techniques to the new format
+# - 4.3.7        : Drop tables expectedreports and expectesreportsnodes on upgrade
 ####################################################################################
 
 # Some paths
@@ -490,6 +491,15 @@ upgrade_database() {
     ${PSQL} -d ${SQL_DATABASE} -f ${RUDDER_UPGRADE_TOOLS}/dbMigration-4.1.x-4.1.12-add-compliancelevel-table.sql > /dev/null
     echo " Done"
   fi
+
+  # - * => 4.3.7 : Drop expectedreports and expectesreportsnodes table 
+  RES=$(${PSQL} -t -d ${SQL_DATABASE} -c "select count(*) from information_schema.columns where lower(table_name) = 'expectedreports'")
+  if [ $RES -ne 0 ]; then
+    echo -n "INFO: Droping deprecated tables 'expectedreports' and 'expectedreportsnodes'"
+    ${PSQL} -d ${SQL_DATABASE} -c "DROP TABLE expectedreportsnodes; DROP TABLE expectedreports;" > /dev/null
+    echo " Done"
+  fi
+
 
   # Now check the fileFormat in the eventlog
   upgrade_eventlog


### PR DESCRIPTION
https://issues.rudder.io/issues/13770