### PR TITLE
Fixes #13929: When we stop rudder-jetty, it says it stops Jetty 7 (we are using Jetty 9 ...)

### DIFF
--- a/rudder-jetty/SOURCES/patches/jetty/jetty-init-lsb-fix-debian.patch
+++ b/rudder-jetty/SOURCES/patches/jetty/jetty-init-lsb-fix-debian.patch
@@ -10,7 +10,7 @@
 +# Required-Stop:     $local_fs $remote_fs $network $syslog
 +# Default-Start:     2 3 4 5
 +# Default-Stop:      0 1 6
-+# Short-Description: Jetty 7 webserver
++# Short-Description: Jetty webserver
 +# Description:       Jetty init script modified by Normation
 +### END INIT INFO
 +

--- a/rudder-jetty/SOURCES/patches/jetty/jetty-init-lsb-fix-rpm.patch
+++ b/rudder-jetty/SOURCES/patches/jetty/jetty-init-lsb-fix-rpm.patch
@@ -14,7 +14,7 @@
 +# Required-Stop:                $local_fs $remote_fs $network
 +# Default-Start:                3 5
 +# Default-Stop:                 0 1 2 6
-+# Short-Description:            Jetty 7 webserver
++# Short-Description:            Jetty webserver
 +# Description:                  Jetty init script modified by Normation
 +### END INIT INFO
 +


### PR DESCRIPTION
https://issues.rudder.io/issues/13929