### PR TITLE
Fixes #14024: Rudder-jetty depends on jdk8 but always try to install jdk9 as dependency

### DIFF
--- a/rudder-jetty/debian/control
+++ b/rudder-jetty/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.rudder-project.org
 
 Package: rudder-jetty
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, java8-runtime-headless | openjdk-8-jre-headless | oracle-java8-installer
+Depends: ${shlibs:Depends}, ${misc:Depends}, openjdk-8-jre-headless | oracle-java8-installer | java8-runtime-headless
 Conflicts: java9-runtime-headless, java9-runtime
 Description: Configuration management and audit tool - Jetty application server
  Rudder is an open source configuration management and audit solution.


### PR DESCRIPTION
https://issues.rudder.io/issues/14024