### PR TITLE
Fixes #11630: When installing a rudder root server (on centos), it asks to run rudder-node-to-relay

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -295,6 +295,9 @@ install -m 644 %{SOURCE23} %{buildroot}%{ruddervardir}/configuration-repository/
 #=================================================
 # Pre Installation
 #=================================================
+mkdir -p /opt/rudder/etc
+echo 'root' > /opt/rudder/etc/uuid.hive
+
 service rudder-jetty stop
 if [ -x /opt/rudder/bin/rudder-pkg ]
 then

--- a/rudder-webapp/debian/preinst
+++ b/rudder-webapp/debian/preinst
@@ -16,6 +16,8 @@ set -e
 
 case "$1" in
     install)
+      mkdir -p /opt/rudder/etc
+      echo 'root' > /opt/rudder/etc/uuid.hive
     ;;
 
     upgrade)


### PR DESCRIPTION
https://issues.rudder.io/issues/11630