### PR TITLE
Fixes #14348: Failed to chdir into '/var/rudder/inventories' while installing rudde-agent 5.1 on centos7

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -453,6 +453,7 @@ rm -f %{_builddir}/file.list.%{name}
 %dir %{ruddervardir}/tmp
 %dir %{ruddervardir}/ncf/common
 %dir %{ruddervardir}/ncf/local
+%dir %{ruddervardir}/inventories
 %dir %{ruddervardir}/tools
 %dir %{rudderlogdir}/install
 %dir %{rudderlogdir}/agent-check


### PR DESCRIPTION
https://issues.rudder.io/issues/14348