### PR TITLE
Fixes #14827: Error when upgrading to Rudder 5.0.10 using centos7  with custom postgresql

### DIFF
--- a/rudder-reports/SPECS/rudder-reports.spec
+++ b/rudder-reports/SPECS/rudder-reports.spec
@@ -112,7 +112,7 @@ install -m 644 %{SOURCE3} %{buildroot}/opt/rudder/etc/server-roles.d/
 #=================================================
 
 POSTGRESQL_SERVICE_NAME=$(systemctl list-unit-files --type service | awk -F'.' '{print $1}' | grep -E "^postgresql-?[0-9]*$" | tail -n 1)
-%if 0%{?suse_version} < 1500
+%if 0%{?suse_version} && 0%{?suse_version} < 1500
   POSTGRESQL_SERVICE_NAME=$(chkconfig 2>/dev/null | awk '{ print $1 }' | grep "postgresql" | tail -n 1)
 %endif
 


### PR DESCRIPTION
https://issues.rudder.io/issues/14827