### PR TITLE
Fixes #4124: Rudder-Webapp build depends on jdk8 which is not available on debian10

### DIFF
--- a/rudder-webapp/debian/control
+++ b/rudder-webapp/debian/control
@@ -2,7 +2,7 @@ Source: rudder-webapp
 Section: web
 Priority: extra
 Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
-Build-Depends: debhelper (>= 9), python3-dev, ca-certificates, curl, openjdk-8-jdk-headless
+Build-Depends: debhelper (>= 9), python3-dev, ca-certificates, curl, openjdk-8-jdk-headless | openjdk-11-jdk-headless
 Standards-Version: 3.8.0
 Homepage: http://www.rudder-project.org
 


### PR DESCRIPTION
https://redmine.normation.com/issues/4124