### PR TITLE
Fixes #15067: rudder-server-relay depends of apache2-mod_wsgi-python3 on sles which does not exist

### DIFF
--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -93,7 +93,11 @@ Requires: python3, python3-mod_wsgi
 BuildRequires: python
 Requires: python, apache2-mod_wsgi, python-pyOpenSSL
 %endif
-%if 0%{?suse_version} && 0%{?suse_version} >= 1500
+%if 0%{?suse_version} && 0%{?suse_version} == 1500
+BuildRequires: python
+Requires: python, apache2-mod_wsgi-python
+%endif
+%if 0%{?suse_version} && 0%{?suse_version} > 1500
 BuildRequires: python3
 Requires: python3, apache2-mod_wsgi-python3
 %endif

--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -97,10 +97,6 @@ Requires: python, apache2-mod_wsgi, python-pyOpenSSL
 BuildRequires: python
 Requires: python, apache2-mod_wsgi-python
 %endif
-%if 0%{?suse_version} && 0%{?suse_version} > 1500
-BuildRequires: python3
-Requires: python3, apache2-mod_wsgi-python3
-%endif
 
 %description
 Rudder is an open source configuration management and audit solution.

--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -122,11 +122,6 @@ Requires: python, apache2-mod_wsgi, python-pyOpenSSL
 BuildRequires: python
 Requires: python, apache2-mod_wsgi-python
 %endif
-%if 0%{?suse_version} && 0%{?suse_version} > 1500
-BuildRequires: python3
-Requires: python3, apache2-mod_wsgi-python3
-%endif
-
 
 %description
 Rudder is an open source configuration management and audit solution.

--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -118,7 +118,11 @@ Requires: python3, python3-mod_wsgi
 BuildRequires: python
 Requires: python, apache2-mod_wsgi, python-pyOpenSSL
 %endif
-%if 0%{?suse_version} && 0%{?suse_version} >= 1500
+%if 0%{?suse_version} && 0%{?suse_version} == 1500
+BuildRequires: python
+Requires: python, apache2-mod_wsgi-python
+%endif
+%if 0%{?suse_version} && 0%{?suse_version} > 1500
 BuildRequires: python3
 Requires: python3, apache2-mod_wsgi-python3
 %endif


### PR DESCRIPTION
https://issues.rudder.io/issues/15067