### PR TITLE
Fixes #15068: rudder-server-webapp depends on jdk >= 1.8 on sles15 but the package is no longer distributed

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -101,7 +101,7 @@ BuildRequires: libopenssl-devel
 %endif
 
 %if 0%{?sle_version} && 0%{?sle_version} >= 150000
-Requires: jdk >= 1.8 insserv-compat
+Requires: jre-headless >= 8 insserv-compat
 %endif
 
 ## Python 3


### PR DESCRIPTION
https://issues.rudder.io/issues/15068