### PR TITLE
Fixes #15075: Use G1GC to better deal with high volume of nodes and reports

### DIFF
--- a/rudder-jetty/SOURCES/rudder-jetty.conf
+++ b/rudder-jetty/SOURCES/rudder-jetty.conf
@@ -37,12 +37,15 @@ fi
 JAVA_XMX=${JAVA_XMX:=1024}
 JAVA_MAXPERMSIZE=${JAVA_MAXPERMSIZE:=256}
 
+# Defaults Garbage Collector settings
+JAVA_GC=${JAVA_GC:="-XX:+UseConcMarkSweepGC
+-XX:+CMSClassUnloadingEnabled"}
+
 # Java VM arguments
 JAVA_OPTIONS="${JAVA_OPTIONS}
 -server
 -Xms${JAVA_XMX}m -Xmx${JAVA_XMX}m
--XX:+CMSClassUnloadingEnabled
--XX:+UseConcMarkSweepGC
+${JAVA_GC}
 -Dfile.encoding=UTF-8
 -Drudder.configFile=/opt/rudder/etc/rudder-web.properties
 -Drudder.authFile=/opt/rudder/etc/rudder-users.xml

--- a/rudder-jetty/SOURCES/rudder-jetty.default
+++ b/rudder-jetty/SOURCES/rudder-jetty.default
@@ -23,6 +23,19 @@ JAVA_MAXPERMSIZE=256
 #
 #JAVA_OPTIONS=""
 
+# Java Garbage collector option
+# On large heap (6 Go or more) and loaded platforms, ConcurrentMarkSweep (default GC 
+# for Rudder) becomes inefficient and Rudder can experience long "stop the world" 
+# garbage collections.
+# To avoid that, you can use G1GC which leads to faster (or no) full GC on big heap,
+# at the prize of a less throughout and a need of some more memory to work 
+# efficiently (~10%).
+# You can also tune you GC option here.
+#
+#JAVA_GC="-XX:+UseG1GC
+#-XX:+UnlockExperimentalVMOptions
+#-XX:MaxGCPauseMillis=500"
+
 # Java VM location
 #
 # This script should be able to automatically detect the majority of


### PR DESCRIPTION
https://issues.rudder.io/issues/15075