### PR TITLE
Fixes #13072: support-info script doesn't correctly detect jetty process with Rudder 4.3+

### DIFF
--- a/rudder-agent/SOURCES/debug-script/tests/rudder_processes
+++ b/rudder-agent/SOURCES/debug-script/tests/rudder_processes
@@ -18,7 +18,7 @@ rudder_processes() {
   type httpd >/dev/null 2>/dev/null && APACHE_NAME="httpd" || APACHE_NAME="apache2"
 
   # For each core Rudder component process
-  for i in slapd /opt/rudder/jetty7 postgres "${APACHE_NAME}"
+  for i in slapd /opt/rudder/jetty postgres "${APACHE_NAME}"
   do
 
     PROCESS_COMMAND=`processutils_getcommand "${i}"`


### PR DESCRIPTION
https://issues.rudder.io/issues/13072