### PR TITLE
Fixes #15417: rudder-webapp package cannot install, as the webapp exits when the ldap is not initialized 

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -439,7 +439,8 @@ then
   /opt/rudder/bin/rudder-pkg plugin restore-status < /tmp/rudder-plugins-upgrade
 fi
 
-service rudder-jetty start
+# this may fails when ldap is not yet initialized
+service rudder-jetty start || true
 
 %postun -n rudder-webapp
 #=================================================

--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -135,7 +135,8 @@ case "$1" in
 
   # Restart the webapp
   echo -n "INFO: Restarting Rudder webapp and inventory-endpoint..."
-  service rudder-jetty start >/dev/null 2>&1
+  # this may fails when ldap is not yet initialized
+  service rudder-jetty start >/dev/null 2>&1 || true
   echo " Done"
 
     ;;


### PR DESCRIPTION
https://issues.rudder.io/issues/15417