### PR TITLE
Fixes #15484: Rudder-pkg should use python3 when available and its dependencies should be resolved at package install

### DIFF
--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -82,20 +82,20 @@ Requires: pwdutils cron
 ## Python 3
 %if 0%{?rhel} && 0%{?rhel} == 7
 BuildRequires: python
-Requires: python, mod_wsgi
+Requires: python, python-devel, python-lxml, python-requests, mod_wsgi
 %endif
 %if 0%{?rhel} && 0%{?rhel} == 8
 BuildRequires: python3
-Requires: python3, python3-mod_wsgi
+Requires: python3, python3-lxml, python3-mod_wsgi
 %endif
 # Doc for suse versioning https://en.opensuse.org/openSUSE:Packaging_for_Leap
 %if 0%{?suse_version} && 0%{?suse_version} < 1500
 BuildRequires: python
-Requires: python, apache2-mod_wsgi, python-pyOpenSSL
+Requires: python, python-lxml, python-requests, apache2-mod_wsgi, python-pyOpenSSL
 %endif
 %if 0%{?suse_version} && 0%{?suse_version} >= 1500
 BuildRequires: python3
-Requires: python3, apache2-mod_wsgi-python3
+Requires: python3, python3-lxml, python3-requests, apache2-mod_wsgi-python3
 %endif
 
 %description

--- a/rudder-server-relay/debian/control
+++ b/rudder-server-relay/debian/control
@@ -2,7 +2,7 @@ Source: rudder-server-relay
 Section: web
 Priority: extra
 Maintainer: Rudder Team <dev@rudder.io>
-Build-Depends: debhelper (>= 9), python3-dev, ca-certificates, curl, pkg-config, libpq-dev, libssl-dev, zlib1g-dev
+Build-Depends: debhelper (>= 9), python3-dev, python3-requests, python3-lxml, ca-certificates, curl, pkg-config, libpq-dev, libssl-dev, zlib1g-dev
 Standards-Version: 3.8.0
 Homepage: https://www.rudder.io
 


### PR DESCRIPTION
https://issues.rudder.io/issues/15484