### PR TITLE
Fixes #15495: Python deps for rudder-pkg are listed in build-depends instead of depends

### DIFF
--- a/rudder-server-relay/debian/control
+++ b/rudder-server-relay/debian/control
@@ -2,13 +2,13 @@ Source: rudder-server-relay
 Section: web
 Priority: extra
 Maintainer: Rudder Team <dev@rudder.io>
-Build-Depends: debhelper (>= 9), python3-dev, python3-requests, python3-lxml, ca-certificates, curl, pkg-config, libpq-dev, libssl-dev, zlib1g-dev
+Build-Depends: debhelper (>= 9), python3-dev, ca-certificates, curl, pkg-config, libpq-dev, libssl-dev, zlib1g-dev
 Standards-Version: 3.8.0
 Homepage: https://www.rudder.io
 
 Package: rudder-server-relay
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3, ${rudder:deps}, apache2, apache2-utils, rsyslog, openssl, libapache2-mod-wsgi-py3, cron, binutils, xz-utils, zlib1g, libpq5, systemd
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-requests, python3-lxml, ${rudder:deps}, apache2, apache2-utils, rsyslog, openssl, libapache2-mod-wsgi-py3, cron, binutils, xz-utils, zlib1g, libpq5, systemd
 Description: Configuration management and audit tool - Server relay package
  Rudder is an open source configuration management and audit solution.
  .


### PR DESCRIPTION
https://issues.rudder.io/issues/15495