### PR TITLE
Fixes #15508: Rights of ncf-api-venv home are not correct (at least on debian 9) preventing usage of technique editor

### DIFF
--- a/rudder-webapp/SOURCES/rudder-webapp-postinst
+++ b/rudder-webapp/SOURCES/rudder-webapp-postinst
@@ -23,6 +23,8 @@ chown -R rudder-slapd:rudder-slapd /var/rudder/ldap/
 if ! getent passwd ncf-api-venv >/dev/null; then
   useradd --system --shell /bin/false --home-dir /var/lib/ncf-api-venv --groups rudder --comment "ncf API,,," ncf-api-venv >> ${LOG_FILE}
 fi
+chown -R ncf-api-venv:ncf-api-venv /var/lib/ncf-api-venv
+
 echo " Done"
 
 echo -n "INFO: Setting up systemd ..."


### PR DESCRIPTION
https://issues.rudder.io/issues/15508