### PR TITLE
Fixes #15534: Rudder-pkg is missing a dependency of python3-distutils on ubuntu

### DIFF
--- a/rudder-server-relay/debian/control
+++ b/rudder-server-relay/debian/control
@@ -8,7 +8,7 @@ Homepage: https://www.rudder.io
 
 Package: rudder-server-relay
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-requests, python3-lxml, ${rudder:deps}, apache2, apache2-utils, rsyslog, openssl, libapache2-mod-wsgi-py3, cron, binutils, xz-utils, zlib1g, libpq5, systemd
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-distutils, python3-requests, python3-lxml, ${rudder:deps}, apache2, apache2-utils, rsyslog, openssl, libapache2-mod-wsgi-py3, cron, binutils, xz-utils, zlib1g, libpq5, systemd
 Description: Configuration management and audit tool - Server relay package
  Rudder is an open source configuration management and audit solution.
  .


### PR DESCRIPTION
https://issues.rudder.io/issues/15534