### PR TITLE
Fixes #15566: rudder-pkg is listed in the package files and is created in postinst so it can not work

### DIFF
--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -266,6 +266,7 @@ rm -rf %{buildroot}
 /var/rudder/reports/incoming
 /var/rudder/shared-files/
 /var/rudder/share/
+/var/rudder/share/commands/package
 /var/rudder/lib/ssl/
 /var/log/rudder/apache2/
 /usr/lib/systemd/system/rudder-relayd.service

--- a/rudder-server-relay/debian/control
+++ b/rudder-server-relay/debian/control
@@ -2,7 +2,7 @@ Source: rudder-server-relay
 Section: web
 Priority: extra
 Maintainer: Rudder Team <dev@rudder.io>
-Build-Depends: debhelper (>= 9), python3-dev, python3-setuptools, python3-pip, python3-distutils|libpython3.5-stdlib, python3-requests, python3-lxml, ca-certificates, curl, pkg-config, libpq-dev, libssl-dev, zlib1g-dev
+Build-Depends: debhelper (>= 9), python3-dev, python3-setuptools, python3-pip, python3-distutils|libpython3.5-stdlib, python3-requests, python3-lxml, ca-certificates, curl, pkg-config, libpq-dev, libssl-dev, zlib1g-dev, systemd
 Standards-Version: 3.8.0
 Homepage: https://www.rudder.io
 


### PR DESCRIPTION
https://issues.rudder.io/issues/15566