### PR TITLE
Fixes #15588: invalid rpm syntax missing %

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -231,7 +231,7 @@ Requires: dmidecode
 %endif
 
 # dmiecode is provided by kernel-utils on RHEL3
-if 0%{?rhel} && 0%{?rhel} < 4
+%if 0%{?rhel} && 0%{?rhel} < 4
 Requires: kernel-utils
 %endif
 


### PR DESCRIPTION
https://issues.rudder.io/issues/15588