### PR TITLE
Fixes #10623: Hooks content/permissions are changed during Rudder upgrade (for ex  /opt/rudder/etc/hooks.d/policy-generation-node-ready/10-cf-promise-check is replaced)

### DIFF
--- a/rudder-webapp/debian/control
+++ b/rudder-webapp/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.rudder-project.org
 
 Package: rudder-webapp
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${rudder:deps}, apache2, apache2-utils, git-core, rsync, lsb-release, openssl, ldap-utils, postgresql-client (>=9.2), java8-runtime-headless | openjdk-8-jre-headless | oracle-java8-installer
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${rudder:deps}, apache2, apache2-utils, git-core, rsync, lsb-release, openssl, ldap-utils, postgresql-client (>=9.2), java8-runtime-headless | openjdk-8-jre-headless | oracle-java8-installer, acl
 Description: Configuration management and audit tool - webapp
  Rudder is an open source configuration management and audit solution.
  .

--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -133,6 +133,10 @@ case "$1" in
     /opt/rudder/bin/rudder-pkg plugin restore-status < /tmp/rudder-plugins-upgrade
   fi
 
+  cd /
+  setfacl --restore=/tmp/rudder-hooks-upgrade
+
+
   # Restart the webapp
   echo -n "INFO: Restarting Rudder webapp and inventory-endpoint..."
   # this may fails when ldap is not yet initialized

--- a/rudder-webapp/debian/preinst
+++ b/rudder-webapp/debian/preinst
@@ -43,6 +43,7 @@ case "$1" in
         /opt/rudder/bin/rudder-pkg plugin save-status > /tmp/rudder-plugins-upgrade
       fi
 
+      getfacl --recursive /opt/rudder/etc/hooks.d/ > /tmp/rudder-hooks-upgrade
 
     ;;
 


### PR DESCRIPTION
https://issues.rudder.io/issues/10623