### PR TITLE
Fixes #15687: Hooks content/permissions are changed during Rudder upgrade (for ex  /opt/rudder/etc/hooks.d/policy-generation-node-ready/10-cf-promise-check is replaced)

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -449,7 +449,7 @@ then
 fi
 
 cd /
-setfacl --restore=/tmp/rudder-hooks-upgrade
+[ -f /tmp/rudder-hooks-upgrade ] && setfacl --restore=/tmp/rudder-hooks-upgrade
 
 # this may fails when ldap is not yet initialized
 service rudder-jetty start || true

--- a/rudder-webapp/debian/postinst
+++ b/rudder-webapp/debian/postinst
@@ -134,7 +134,7 @@ case "$1" in
   fi
 
   cd /
-  setfacl --restore=/tmp/rudder-hooks-upgrade
+  [ -f /tmp/rudder-hooks-upgrade ] && setfacl --restore=/tmp/rudder-hooks-upgrade
 
 
   # Restart the webapp


### PR DESCRIPTION
https://issues.rudder.io/issues/15687