### PR TITLE
Fixes #15701: Missing build dependencies on rpm based distros for rudder-api-client

### DIFF
--- a/rudder-api-client/SPECS/dependencies
+++ b/rudder-api-client/SPECS/dependencies
@@ -1,0 +1,4 @@
+sles-12:python3 python3-requests
+sles-15:python3 python3-requests
+rhel-7:python3 python3-requests
+rhel-8:python3 python3-requests


### PR DESCRIPTION
https://issues.rudder.io/issues/15701