### PR TITLE
Fixes #15711: Rudder api client expect python3 which is not available by default on rhel7

### DIFF
--- a/rudder-api-client/SPECS/dependencies
+++ b/rudder-api-client/SPECS/dependencies
@@ -1,4 +1,4 @@
-sles-12:python3 python3-requests
+sles-12:python python-requests
 sles-15:python3 python3-requests
-rhel-7:python3 python3-requests
+rhel-7:python python-requests
 rhel-8:python3 python3-requests

--- a/rudder-api-client/SPECS/rudder-api-client.spec
+++ b/rudder-api-client/SPECS/rudder-api-client.spec
@@ -48,9 +48,15 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 AutoReq: 0
 AutoProv: 0
 
+## Python 2
+%if 0%{?rhel} == 7 || 0%{?suse_version} < 1500
+BuildRequires: python, python-requests
+Requires: python, python-requests
+%else
 ## Python 3
 BuildRequires: python3, python3-requests
 Requires: python3, python3-requests
+%endif
 
 %description
 Command line tools and python libraries to call Rudder.
@@ -60,6 +66,11 @@ Command line tools and python libraries to call Rudder.
 #=================================================
 %prep
 %setup -c
+
+# rhel7 does not have python3 so we force python2 instead
+%if 0%{?rhel} == 7 || 0%{?suse_version} < 1500
+find . -type f | xargs sed -i '1,1s|#!/usr/bin/python3|#!/usr/bin/python2|'
+%endif
 
 #=================================================
 # Installation


### PR DESCRIPTION
https://issues.rudder.io/issues/15711