### PR TITLE
Fixes #15825: /var/rudder/reports/failed is not created at install

### DIFF
--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -274,6 +274,7 @@ rm -rf %{buildroot}
 /var/rudder/inventories/incoming
 /var/rudder/inventories/accepted-nodes-updates
 /var/rudder/reports/incoming
+/var/rudder/reports/failed
 /var/rudder/shared-files/
 /var/rudder/share/
 /var/rudder/lib/ssl/


### PR DESCRIPTION
https://issues.rudder.io/issues/15825