### PR TITLE
Fixes #15922: Missing python build dependencies for rudder-api-client on debian builds

### DIFF
--- a/rudder-api-client/debian/control
+++ b/rudder-api-client/debian/control
@@ -2,7 +2,7 @@ Source: rudder-api-client
 Section: web
 Priority: extra
 Maintainer: Rudder Team <dev@rudder.io>
-Build-Depends: debhelper (>= 9), python3, python3-requests
+Build-Depends: debhelper (>= 9), python, python-requests
 Standards-Version: 3.8.0
 Homepage: https://www.rudder.io
 


### PR DESCRIPTION
https://issues.rudder.io/issues/15922