### PR TITLE
Fixes #16054:  Missing /var/rudder/lib/relay dir in packaging - rpm

### DIFF
--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -282,6 +282,7 @@ rm -rf %{buildroot}
 /var/rudder/shared-files/
 /var/rudder/share/
 /var/rudder/lib/ssl/
+/var/rudder/lib/relay/
 /var/log/rudder/apache2/
 /usr/lib/systemd/system/rudder-relayd.service
 /opt/rudder/etc/


### PR DESCRIPTION
https://issues.rudder.io/issues/16054