### PR TITLE
Fixes #15630: When the number of file descriptor openable at the same time is too low, we can get a confusing error at policy generation

### DIFF
--- a/rudder-webapp/SOURCES/rudder-jetty.service
+++ b/rudder-webapp/SOURCES/rudder-jetty.service
@@ -5,6 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=forking
 
+LimitNOFILE=64000
 ExecStart=/opt/rudder/bin/rudder-jetty.sh start
 ExecStop=/opt/rudder/bin/rudder-jetty.sh stop
 SuccessExitStatus=143


### PR DESCRIPTION
https://issues.rudder.io/issues/15630