### PR TITLE
Fixes #14653: rudder-agent installation fails on Ubuntu 18 without systemd

### DIFF
--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -108,6 +108,9 @@ endif
 ifeq (true,$(USE_SYSTEM_XML))
 DEPS := $(DEPS), libxml2
 endif
+ifeq (true,$(USE_SYSTEMD))
+DEPS := $(DEPS), systemd
+endif
 
 configure:
 


### PR DESCRIPTION
https://issues.rudder.io/issues/14653