### PR TITLE
Fixes #16364: service rudder-jetty is not activated after upgrade from 5.0 to 6.0 on centos7

### DIFF
--- a/rudder-reports/SOURCES/rudder-reports-postinst
+++ b/rudder-reports/SOURCES/rudder-reports-postinst
@@ -70,12 +70,9 @@ fi
 # ODOT
 
 # RHEL doesn't autostart service
-if [ "${DB_NOT_INITIALIZED}" != "" ]; then
-  echo -n "INFO: Setting PostgreSQL as a boot service..."
-  systemctl enable ${POSTGRESQL_SERVICE_NAME} >> ${LOG_FILE}
-  echo " Done"
-fi
-
+echo -n "INFO: Setting PostgreSQL as a boot service..."
+systemctl enable ${POSTGRESQL_SERVICE_NAME} >> ${LOG_FILE}
+echo " Done"
 
 echo -n "INFO: Waiting for PostgreSQL to be up..."
 CPT=0

--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -158,9 +158,9 @@ install -m 644 rudder-relay-apache %{buildroot}/etc/sysconfig/rudder-relay-apach
 CFRUDDER_FIRST_INSTALL=$1
 
 %if 0%{?rhel}
-  echo -n "INFO: Setting Apache HTTPd as a boot service..."
-  systemctl enable %{apache} >/dev/null
-  echo " Done"
+echo -n "INFO: Setting Apache httpd as a boot service..."
+systemctl enable %{apache} >/dev/null
+echo " Done"
 %endif
 
 %if 0%{?suse_version}

--- a/rudder-server-root/SOURCES/rudder-server-root-postinst
+++ b/rudder-server-root/SOURCES/rudder-server-root-postinst
@@ -15,15 +15,7 @@ fi
 echo "`date` - Starting rudder-server-root post installation script" >> ${LOG_FILE}
 
 systemctl daemon-reload
-
-# Enable at first install or in migration
-if [ ${CFRUDDER_FIRST_INSTALL} -eq 1 ] || [ -f /var/rudder/tmp/migration-rudder-service-enabled-server ]
-then
-  systemctl enable rudder-server >> ${LOG_FILE}
-fi
-
-# Clean flag
-rm -f /var/rudder/tmp/migration-rudder-service-enabled-server
+systemctl enable rudder-server >> ${LOG_FILE}
 
 # We need it to be able to open big mdb memory-mapped databases
 ulimit -v unlimited

--- a/rudder-server-root/SPECS/rudder-server-root.spec
+++ b/rudder-server-root/SPECS/rudder-server-root.spec
@@ -96,25 +96,6 @@ LOG_FILE="/var/log/rudder/install/%{name}.log"
 
 echo "`date` - Starting %{name} pre installation script" >> ${LOG_FILE}
 
-## WARNING: This script is a copy of a part of the rudder-agent preinst
-
-if [ ${CFRUDDER_FIRST_INSTALL} -ne 1 ]
-then
-  mkdir -p /var/rudder/tmp
-
-  if [ -f /etc/init.d/rudder-server ]
-  then
-    # If old rudder service is here and enabled
-    if type chkconfig > /dev/null
-    then 
-      if chkconfig --list rudder-server 2>&1 | grep -q -e 3:on -e B:on
-      then
-        touch /var/rudder/tmp/migration-rudder-service-enabled-server
-      fi
-    fi
-  fi
-fi
-
 %post
 #=================================================
 # Post Installation

--- a/rudder-server-root/debian/preinst
+++ b/rudder-server-root/debian/preinst
@@ -38,21 +38,6 @@ LOG_FILE="/var/log/rudder/install/${PACKAGE_NAME}.log"
 
 echo "`date` - Starting ${PACKAGE_NAME} pre installation script" >> ${LOG_FILE}
 
-## WARNING: This script is a copy of a part of the rudder-agent preinst
-
-if [ ${CFRUDDER_FIRST_INSTALL} -ne 1 ]
-then
-  mkdir -p /var/rudder/tmp
-
-  if [ -f /etc/init.d/rudder-server ]
-  then
-    if test /etc/rc`/sbin/runlevel | cut -d' ' -f2`.d/S??rudder-server
-    then
-      touch /var/rudder/tmp/migration-rudder-service-enabled-server
-    fi
-  fi
-fi
-
 # We need to be sure that uuid.hive is set to root at beginning
 mkdir -p /opt/rudder/etc
 echo 'root' > /opt/rudder/etc/uuid.hive

--- a/rudder-webapp/SOURCES/rudder-webapp-postinst
+++ b/rudder-webapp/SOURCES/rudder-webapp-postinst
@@ -38,11 +38,8 @@ echo " Done"
 echo -n "INFO: Setting up systemd ..."
 systemctl daemon-reload
 
-if [ "${RUDDER_FIRST_INSTALL}" = "true" ]; then
-  systemctl enable rudder-jetty >> ${LOG_FILE}
-  systemctl enable rudder-slapd >> ${LOG_FILE}
-fi
-echo " Done"
+systemctl enable rudder-jetty >> ${LOG_FILE}
+systemctl enable rudder-slapd >> ${LOG_FILE}
 
 # Remove pidfile and argsfile
 sed -i '/^[ \t]*pidfile/d' "${LDAP_CONF}"


### PR DESCRIPTION
https://issues.rudder.io/issues/16364