### PR TITLE
Fixes #16443: missing /var/rudder/reports/ready/ on centos when migrating from rudder 5.0 to 6.0

### DIFF
--- a/rudder-agent/SOURCES/Makefile
+++ b/rudder-agent/SOURCES/Makefile
@@ -230,6 +230,7 @@ install: build $(INSTALL_DEPS) install-cfengine rudder-agent-utilities rudder-ag
 	mkdir -p $(DESTDIR)/var/rudder/inventories
 	mkdir -p $(DESTDIR)/var/rudder/ncf/local
 	mkdir -p $(DESTDIR)/var/rudder/ncf/common
+	mkdir -p $(DESTDIR)/var/rudder/reports/ready
 	mkdir -p $(DESTDIR)/var/log/rudder/install
 	mkdir -p $(DESTDIR)/var/log/rudder/agent-check
 	mkdir -p $(DESTDIR)/usr/bin

--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -495,6 +495,7 @@ rm -f %{_builddir}/file.list.%{name}
 %dir %{ruddervardir}/ncf/local
 %dir %{ruddervardir}/inventories
 %dir %{ruddervardir}/tools
+%dir %{ruddervardir}/reports/ready
 %dir %{rudderlogdir}/install
 %dir %{rudderlogdir}/agent-check
 

--- a/rudder-agent/debian/dirs
+++ b/rudder-agent/debian/dirs
@@ -10,5 +10,6 @@ var/rudder/tmp
 var/rudder/tools
 var/rudder/ncf/common
 var/rudder/ncf/local
+var/rudder/reports/ready
 var/log/rudder/install
 var/log/rudder/agent-check


### PR DESCRIPTION
https://issues.rudder.io/issues/16443