### PR TITLE
Fixes #16457: Rudder Agent Inventory fails with errors on (CentOS 8 and RHEL 8)

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -151,7 +151,7 @@ Source1: Makefile
 AutoReq: 0
 AutoProv: 0
 
-%if "%{use_system_perl}" == "false"
+%if "%{use_system_perl}" == "true"
 Requires: perl
 %endif
 


### PR DESCRIPTION
https://issues.rudder.io/issues/16457