### PR TITLE
Fixes #16482: Missing recursive option when removing old ncf hooks at rudder-upgrade

### DIFF
--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -313,7 +313,7 @@ upgrade_ncf() {
   if [ -d ${CONFIGURATION_REPOSITORY}/ncf/ncf-hooks.d ]; then
     CURRENT="$(pwd)"
     cd ${CONFIGURATION_REPOSITORY}/ncf
-    git rm -f ncf-hooks.d
+    git rm -rf ncf-hooks.d
     git commit --allow-empty -m "Remove ncf-hooks.d from configuration repository"
     cd ${CURRENT}
   fi


### PR DESCRIPTION
https://issues.rudder.io/issues/16482