### PR TITLE
Fixes #16519: rudder reports installation fails on CentOS 7.7 because /var/log/rudder/install directory does not exist

### DIFF
--- a/rudder-reports/SOURCES/rudder-reports-postinst
+++ b/rudder-reports/SOURCES/rudder-reports-postinst
@@ -5,6 +5,8 @@ DB_NOT_INITIALIZED="$1"
 
 LOG_FILE="/var/log/rudder/install/rudder-reports-$(date +%Y%m%d%H%M%S).log"
 
+mkdir -p /var/log/rudder/install
+
 echo "$(date) - Starting rudder-reports post installation script" >> ${LOG_FILE}
 
 # Try with systemd

--- a/rudder-server-root/SOURCES/rudder-server-root-postinst
+++ b/rudder-server-root/SOURCES/rudder-server-root-postinst
@@ -12,6 +12,8 @@ then
   exit 1
 fi
 
+mkdir -p /var/log/rudder/install
+
 echo "`date` - Starting rudder-server-root post installation script" >> ${LOG_FILE}
 
 systemctl daemon-reload

--- a/rudder-webapp/SOURCES/rudder-webapp-postinst
+++ b/rudder-webapp/SOURCES/rudder-webapp-postinst
@@ -8,6 +8,8 @@ APACHE="$2"
 LOG_FILE="/var/log/rudder/install/rudder-webapp-$(date +%Y%m%d%H%M%S).log"
 LDAP_CONF="/opt/rudder/etc/openldap/slapd.conf"
 
+mkdir -p /var/log/rudder/install
+
 echo "$(date) - Starting rudder-webapp post installation script" >> ${LOG_FILE}
 
 echo -n "INFO: Creating groups ..."


### PR DESCRIPTION
https://issues.rudder.io/issues/16519