### PR TITLE
Fixes #16707: After upgrade from 5.0 to 6.0 on centos7, rudder-slapd is not started

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -359,6 +359,14 @@ then
   systemctl stop rudder-slapd
 fi
 
+#=================================================
+# Post transaction
+#=================================================
+%posttrans -n rudder-webapp
+
+# during upgrade, service may have been stopped by uninstall of rudder-inventory-ldap
+systemctl start rudder-slapd
+
 
 #=================================================
 # Cleaning

--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -365,7 +365,7 @@ fi
 %posttrans -n rudder-webapp
 
 # during upgrade, service may have been stopped by uninstall of rudder-inventory-ldap
-systemctl start rudder-slapd
+systemctl start rudder-slapd >/dev/null
 
 
 #=================================================


### PR DESCRIPTION
https://issues.rudder.io/issues/16707