### PR TITLE
Fixes #16761: rudder-upgrade refers to /opt/rudder/bin/rudder-pkg which doesn't exists in 6.0

### DIFF
--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -532,8 +532,8 @@ EOF
 # Check and upgrade plugins
 ################################################################################
 upgrade_plugins() {
-  /opt/rudder/bin/rudder-pkg check-compatibility
-  /opt/rudder/bin/rudder-pkg rudder-postupgrade
+  rudder package check-compatibility
+  rudder package rudder-postupgrade
 }
 
 ################################################################################


### PR DESCRIPTION
https://issues.rudder.io/issues/16761