### PR TITLE
Fixes #16797: After upgrading from 5.0.16 to 6.0.3 on centos7 with plugins, jetty is stopped

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -366,8 +366,9 @@ fi
 #=================================================
 %posttrans -n rudder-webapp
 
-# during upgrade, service may have been stopped by uninstall of rudder-inventory-ldap
+# during upgrade, service may have been stopped by uninstall of rudder-inventory-ldap or rudder-jetty
 systemctl start rudder-slapd >/dev/null
+systemctl start rudder-jetty >/dev/null
 
 
 #=================================================


### PR DESCRIPTION
https://issues.rudder.io/issues/16797