### PR TITLE
Fixes #17433: Python scripts on rhel7 are set to use python3 which is not available

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -137,6 +137,10 @@ Rudder.
 %prep
 
 cd %{_sourcedir}
+# rhel7 doesn't have python 3 so we force python2 instead
+%if 0%{?rhel} == 7 || ( 0%{?suse_version} && 0%{?suse_version} < 1500 )
+find . -type f | xargs sed -i '1,1s|#!/usr/bin/python3|#!/usr/bin/python2|'
+%endif
 make --debug rudder-sources
 
 


### PR DESCRIPTION
https://issues.rudder.io/issues/17433