### PR TITLE
Fixes #17681: Upgrade to 6.1 fails on httpd start beacause of old ncf conf is still present on rpm

### DIFF
--- a/rudder-webapp/SPECS/rudder-webapp.spec
+++ b/rudder-webapp/SPECS/rudder-webapp.spec
@@ -281,6 +281,10 @@ then
   sed -i 's%APACHE_MODULES="${APACHE_MODULES} rewrite dav dav_fs proxy proxy_http.*%# This sources the Rudder needed by Rudder\n. /etc/sysconfig/rudder-webapp-apache%' /etc/sysconfig/apache2
 fi
 
+# Remove old ncf-api-virtualenv conf, or else it will prevent apache start 
+rm -f /etc/%{apache_vhost_dir}/ncf-api-virtualenv.conf
+
+
 /opt/rudder/share/package-scripts/rudder-webapp-postinst "${FIRST_INSTALL}" "%{apache}"
 
 %if 0%{?rhel}


### PR DESCRIPTION
https://issues.rudder.io/issues/17681