### PR TITLE
Fixes #18139: if configuration files are replaced during upgrade, rudder-upgrade fails on both postgresql checks and plugins disabling

### DIFF
--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -230,6 +230,8 @@ update_credentials() {
     else
       sed -i "s%ldap.authpw[ \t]*=.*%ldap.authpw=${REFERENCE_LDAP_PASSWORD}%" /opt/rudder/etc/${property_file}
       LDAP_PASSWORD=${REFERENCE_LDAP_PASSWORD}
+      # Need to restart rudder-slapd so that services can connect to it
+      systemctl restart rudder-slapd
       echo -n " LDAP Credentials updated, "
     fi
 
@@ -243,6 +245,7 @@ update_credentials() {
       # Credentials from the properties and the rudder-password.conf do not match, update the properties.
       sed -i "s%rudder.jdbc.password[ \t]*=.*%rudder.jdbc.password=${REFERENCE_SQL_PASSWORD}%" /opt/rudder/etc/${property_file}
       SQL_PASSWORD=${REFERENCE_SQL_PASSWORD}
+      export PGPASSWORD="${SQL_PASSWORD}"
       echo " SQL Credentials updated"
     fi
 


### PR DESCRIPTION
https://issues.rudder.io/issues/18139