### PR TITLE
Fixes #18747: missing python3-setuptools dependency on relay on sles15 and rhel6

### DIFF
--- a/rudder-server-relay/SPECS/dependencies
+++ b/rudder-server-relay/SPECS/dependencies
@@ -1,5 +1,5 @@
 sles-12:python-devel python-setuptools python-lxml python-requests pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
-sles-15:python3-devel python3-setuptools python3-pip python3-lxml python3-requests pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
+sles-15:python3-devel python3-pip python3-lxml python3-requests pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
 rhel-7:python-devel python-setuptools pythons-libs python-lxml python-requests selinux-policy-devel pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
-rhel-8:python3-devel python3-setuptools python3-pip python3-lxml python3-requests selinux-policy-devel pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
+rhel-8:python3-devel python3-pip python3-lxml python3-requests selinux-policy-devel pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
 rust:yes

--- a/rudder-server-relay/SPECS/dependencies
+++ b/rudder-server-relay/SPECS/dependencies
@@ -1,5 +1,5 @@
 sles-12:python-devel python-setuptools python-lxml python-requests pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
-sles-15:python3-devel python3-pip python3-lxml python3-requests pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
+sles-15:python3-devel python3-setuptools python3-pip python3-lxml python3-requests pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
 rhel-7:python-devel python-setuptools pythons-libs python-lxml python-requests selinux-policy-devel pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
-rhel-8:python3-devel python3-pip python3-lxml python3-requests selinux-policy-devel pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
+rhel-8:python3-devel python3-setuptools python3-pip python3-lxml python3-requests selinux-policy-devel pkgconfig postgresql-devel openssl-devel zlib-devel xz-devel
 rust:yes

--- a/rudder-server-relay/SPECS/rudder-server-relay.spec
+++ b/rudder-server-relay/SPECS/rudder-server-relay.spec
@@ -103,7 +103,7 @@ BuildRequires: python, python-setuptools, python-lxml, python-requests
 Requires: python, python-setuptools, python-lxml, python-requests
 %else
 BuildRequires: python3, python3-pip, python3-lxml, python3-requests
-Requires: python3, python3-lxml, python3-requests
+Requires: python3, python3-lxml, python3-requests, python3-setuptools
 %endif
 
 %description


### PR DESCRIPTION
https://issues.rudder.io/issues/18747