### PR TITLE
Fixes #18842: After upgrade between two Rudder 6.2 all plugins are disabled

### DIFF
--- a/rudder-webapp/SOURCES/rudder-upgrade
+++ b/rudder-webapp/SOURCES/rudder-upgrade
@@ -645,6 +645,7 @@ upgrade_plugins() {
   else
     echo "Plugins were not updated, because connection test is failing, please upgrade your plugins manually"  
   fi
+  rudder package plugin restore-status < /tmp/rudder-plugins-upgrade || true
   rudder package check-compatibility --version=6.2 || true
 }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/18842