### PR TITLE
Fixes #18855: Make api/status "isAlive" api available from other hosts than localhost

### DIFF
--- a/rudder-webapp/SOURCES/rudder-apache-webapp-common.conf
+++ b/rudder-webapp/SOURCES/rudder-apache-webapp-common.conf
@@ -48,24 +48,6 @@ ProxyErrorOverride On
   Require all granted
 </Directory>
 
-# Deny the use of legacy API if using X-API-Version which is not '1'
-SetEnvIf X-API-Version "[^1]" api_deny
-# NO access to the status and archiving API unless you are localhost
-<LocationMatch "^/rudder/api/(status|archives)$">
-  <RequireAll>
-    Require local
-    Require not env api_deny
-  </RequireAll>
-</LocationMatch>
-
-# NO access to the reloading API either unless you are localhost
-<LocationMatch "^/rudder/api/(techniqueLibrary|dyngroup|deploy)/reload$">
-  <RequireAll>
-    Require local
-    Require not env api_deny
-  </RequireAll>
-</LocationMatch>
-
 # Note: The preceding statements are here for compatibility purpose and will
 # be removed in a future version of Rudder, which will enforce authenticated
 # calls to every API part.


### PR DESCRIPTION
https://issues.rudder.io/issues/18855

Two things in that PR:

- all API v1 (but "/api/status") are deleted. We can remove all logic in place to taking care of them, 
- we want to make "/api/status" available from everywhere: remove restriction logic for it.

And since we want to make as little friction as possible for `/api/status`, we don't even require any version header.