### PR TITLE
Fix for embedded system without uuidgen

### DIFF
--- a/rudder-agent/SOURCES/rudder-uuidgen
+++ b/rudder-agent/SOURCES/rudder-uuidgen
@@ -8,6 +8,11 @@ elif [ -x /usr/bin/uuidgen ]
 then
   /usr/bin/uuidgen
 
+# bare linux
+elif [ -f /proc/sys/kernel/random/uuid ]
+then
+  cat /proc/sys/kernel/random/uuid
+
 # AIX 7.2
 elif [ -x /usr/bin/uuid_get ]
 then


### PR DESCRIPTION
uuidgen is not installed on my arm device