### PR TITLE
Fixes #19017: Do not pass xFLAGS as environment in packaging -  fail to build on rhel5

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -86,6 +86,9 @@ DESTDIR = $(CURDIR)/target
 # Pass an empty string to skip hash check
 GET=get() { @_GET@ "$$1.part" "$$2" && { openssl dgst -sha256 "$$1.part" | grep -q "$$3" || { echo "Wrong checksum, aborting"; exit 1; }; } && mv "$$1.part" "$$1"; }; get
 
+# do not pass variables to sub make
+MAKEOVERRIDES = 
+
 ################
 # Main targets #
 ################
@@ -200,7 +203,7 @@ debug-script/rudder-debug-info:
 
 build-client: rudder-sources tomlc99-source @libcurl_DEP@
 	cp -r tomlc99-source rudder-sources/rudder/agent/sources/client/tomlc99
-	cd rudder-sources/rudder/agent/sources/client && $(MAKE) build-release STATIC_TOML=1 $(BUILD_FLAGS_EXE)
+	cd rudder-sources/rudder/agent/sources/client && $(MAKE) MAKEFLAGS= build-release STATIC_TOML=1 $(BUILD_FLAGS_EXE)
 	touch $@
 
 build-zlib: zlib-source

--- a/rudder-agent/SOURCES/configure
+++ b/rudder-agent/SOURCES/configure
@@ -283,7 +283,8 @@ LMDB_LDFLAGS = ${LMDB_LDFLAGS}
 PIE_CFLAGS = ${PIE_CFLAGS}
 PIE_LDFLAGS = ${PIE_LDFLAGS}
 
-CFLAGS = \$(BUILD_CFLAGS) ${SECURE_CFLAGS}
+# -I for includes from dependencies
+CFLAGS = \$(BUILD_CFLAGS) ${SECURE_CFLAGS} -I\$(CURDIR)/dependencies/opt/rudder/include
 # -L for searching libs in the right place while they are not installed at their final place
 LDFLAGS = \$(BUILD_LDFLAGS) ${SECURE_LDFLAGS} ${SYSTEM_LDFLAGS} -L\$(CURDIR)/dependencies/opt/rudder/lib
 BUILD_FLAGS_EXE = CFLAGS=\"\$(CFLAGS) \$(PIE_CFLAGS)\" LDFLAGS=\"\$(LDFLAGS) \$(PIE_LDFLAGS)\"


### PR DESCRIPTION
https://issues.rudder.io/issues/19017