### PR TITLE
Fixes #19144: The Generic Method "File copy from Rudder shared Folder" ignores Audit policy mode

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/19144-warn-copy-file-directory.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/19144-warn-copy-file-directory.patch
@@ -1,0 +1,49 @@
+diff --git a/cf-agent/verify_files_utils.c b/cf-agent/verify_files_utils.c
+index cc90db0c9..a060d3c8a 100644
+--- a/cf-agent/verify_files_utils.c
++++ b/cf-agent/verify_files_utils.c
+@@ -329,7 +329,16 @@ static PromiseResult CfCopyFile(EvalContext *ctx, char *sourcefile,
+     }
+     else
+     {
+-        MakeParentDirectory(destfile, true);
++        if (DONTDO || (attr.transaction.action == cfa_warn))
++        {
++         Log(LOG_LEVEL_VERBOSE,
++                    "Skipping directory creation for '%s' as only a warning was promised",
++                    destfile);
++        }
++        else
++        {
++            MakeParentDirectory(destfile, true);
++        }
+     }
+ 
+     if (attr.copy.min_size != CF_NOINT)
+@@ -2703,13 +2712,20 @@ static PromiseResult CopyFileSources(EvalContext *ctx, char *destination, const
+         strcat(vbuff, ".");
+     }
+ 
+-    if (!MakeParentDirectory(vbuff, attr->move_obstructions))
++    if (DONTDO || (attr->transaction.action == cfa_warn))
+     {
+-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
+-             "Can't make directories for '%s' in files.copy_from promise",
+-             vbuff);
+-        BufferDestroy(source);
+-        return PROMISE_RESULT_FAIL;
++        Log(LOG_LEVEL_VERBOSE, "Skipping directories creation for '%s' only a warning was promised", vbuff);
++    }
++    else
++    {
++        if (!MakeParentDirectory(vbuff, attr->move_obstructions))
++        {
++            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
++                 "Can't make directories for '%s' in files.copy_from promise",
++                 vbuff);
++            BufferDestroy(source);
++            return PROMISE_RESULT_FAIL;
++        }
+     }
+ 
+     CompressedArray *inode_cache = NULL;


### PR DESCRIPTION
https://issues.rudder.io/issues/19144