### PR TITLE
Fixes #19429: rudder-agent-postinst fails in 7.0 while closing fd

### DIFF
--- a/rudder-agent/SOURCES/rudder-agent-postinst
+++ b/rudder-agent/SOURCES/rudder-agent-postinst
@@ -16,7 +16,10 @@ if [ -d /proc/self/fd ] && [ "$(uname -s)" != "SunOS" ]
 then
   for f in /proc/self/fd/*; do
     fd=$(basename "${f}")
-    [ "$fd" -gt 2 ] && eval "exec $fd>&-"
+    if [ "$fd" -gt 2 ] && [ -e "$fd" ]
+    then
+      eval "exec $fd>&-"
+    fi
   done
 fi
 


### PR DESCRIPTION
https://issues.rudder.io/issues/19429