### PR TITLE
Fixes #20122: ubuntu 13 doesn't support tlsv1.2 

### DIFF
--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -56,6 +56,7 @@ USE_PIE=false
 endif
 # Ubuntu 13.04
 ifeq (raring,$(OS_CODENAME))
+USE_HTTPS=false
 USE_SYSTEMD=false
 USE_SYSTEM_JQ=false
 USE_PIE=false


### PR DESCRIPTION
https://issues.rudder.io/issues/20122