### PR TITLE
Fixes #20255: There is no cfengine-systemd patch anymore thus making package build faild

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -137,7 +137,6 @@ install: install-agent
 @cfengine_SOURCE@
 	# Apply patches
 	for PATCHNAME in patches/cfengine/*.patch; do echo "Applying $$PATCHNAME..."; $(PATCH) -d ./cfengine-source -p1 < $$PATCHNAME; echo ""; done
-	@IF_systemd@ for PATCHNAME in patches/cfengine-systemd/*.patch; do echo "Applying $$PATCHNAME..."; $(PATCH) -d ./cfengine-source -p1 < $$PATCHNAME; echo ""; done
 	# Make sure there were no rejects
 	test `find ./cfengine-source -name \*.rej | wc -l` = 0
 


### PR DESCRIPTION
https://issues.rudder.io/issues/20255