### PR TITLE
Fixes #20376: rudder-webapp 6.2 on debian11 generate a dbgsym package

### DIFF
--- a/rudder-webapp/debian/rules
+++ b/rudder-webapp/debian/rules
@@ -10,6 +10,10 @@ include /usr/share/dpkg/buildflags.mk
 # We have no test
 override_dh_auto_test:
 
+override_dh_strip:
+	dh_strip --no-automatic-dbgsym
+
+
 override_dh_gencontrol:
 	dh_gencontrol -- "-Vrudder:deps=$(shell ../format-dependencies dpkg $(shell dpkg-parsechangelog -SVersion) rudder-server-relay)"
 


### PR DESCRIPTION
https://issues.rudder.io/issues/20376