### PR TITLE
Fixes #20450: Separate openldap cache between nightly and release builds - 6.2

### DIFF
--- a/rudder-webapp/SOURCES/Makefile
+++ b/rudder-webapp/SOURCES/Makefile
@@ -32,6 +32,7 @@ OPENLDAP_RELEASE = 2.4.47
 OPENLDAP_SHA256 = f54c5877865233d9ada77c60c0f69b3e0bfd8b1b55889504c650047cc305520b
 TMP_DIR := $(shell mktemp -dq)
 PYTHON = python3
+RELEASE_TYPE := $(shell if echo ${RUDDER_VERSION_TO_PACKAGE} | grep -q git; then echo nightly; else echo release; fi)
 
 DESTDIR = $(CURDIR)/target
 APACHE_VHOSTDIR = apache2/sites-available
@@ -130,7 +131,7 @@ rudder-doc:
 	mv doc-${RUDDER_MAJOR_VERSION} rudder-doc/html
 
 PATCHES_SHA = $(shell find patches/ -type f | sort | xargs sha256sum | sha256sum | awk '{print $$1}')
-CACHE_PARAMETERS = --with-env name=openldap ldap=$(OPENLDAP_SHA256) patches=$(PATCHES_SHA)
+CACHE_PARAMETERS = --with-env name=openldap ldap=$(OPENLDAP_SHA256) patches=$(PATCHES_SHA) release_type=$(RELEASE_TYPE)
 BUILD_LDAP = $(shell ../../build-caching get openldap-source/ $(CACHE_PARAMETERS) || echo build-ldap)
 build: $(BUILD_LDAP) rudder-sources build-rudder-lang rudder-doc jetty rudder.war
 	# save ldap build into cache


### PR DESCRIPTION
https://issues.rudder.io/issues/20450