### PR TITLE
Fixes #21035: Ubuntu 22 needs python3 as build dependency for rudder-agent

### DIFF
--- a/rudder-agent/debian/control
+++ b/rudder-agent/debian/control
@@ -2,7 +2,7 @@ Source: rudder-agent
 Section: admin
 Priority: extra
 Maintainer: Rudder Team <dev@rudder.io>
-Build-Depends: debhelper (>= 7), bison, gcc, flex, autoconf, automake, libtool, libpcre3-dev, libpam0g-dev, ca-certificates, perl, lsb-release, libyaml-dev, libxml2-dev, libacl1-dev, python, rsync, libssl-dev, libcurl4-openssl-dev, libmodule-corelist-perl, libmodule-install-perl, libreadline-dev, pkg-config, libsystemd-dev | aegis
+Build-Depends: debhelper (>= 7), bison, gcc, flex, autoconf, automake, libtool, libpcre3-dev, libpam0g-dev, ca-certificates, perl, lsb-release, libyaml-dev, libxml2-dev, libacl1-dev, python | python3, rsync, libssl-dev, libcurl4-openssl-dev, libmodule-corelist-perl, libmodule-install-perl, libreadline-dev, pkg-config, libsystemd-dev | aegis
 # Hack: aegis exist on old distros (debian<=8) but not on server distros (debian>=9) where we need libsystemd-dev so this will work unconditionnaly
 Standards-Version: 3.8.0
 Homepage: https://www.rudder.io


### PR DESCRIPTION
https://issues.rudder.io/issues/21035