### PR TITLE
Fixes #21151: Make rudder-jetty.conf and default rudder-jetty compatible with JVM 11 and 17

### DIFF
--- a/rudder-server/SOURCES/rudder-jetty.conf
+++ b/rudder-server/SOURCES/rudder-jetty.conf
@@ -13,7 +13,7 @@ ver() { printf "%03d%03d" `echo "$1" | tr '.' ' '`; }
 
 if [ -z "${JAVA_HOME}" ]
 then
-    ## We support OpenJDK 8 onwards, privilege latest versions (sort -r) while searching for JAVA_HOME
+    ## We support OpenJDK 11 onwards, privilege latest versions (sort -r) while searching for JAVA_HOME
     if [ -d /usr/lib/jvm ]; then JAVA_HOME=$(find /usr/lib/jvm -maxdepth 1 -type d -name 'java-11-openjdk-*' | sort -r | head -n1); fi
     if [ -d /usr/java ]; then JAVA_HOME=/usr/java/latest; fi
 fi
@@ -38,14 +38,25 @@ JAVA_XMX=${JAVA_XMX:=1024}
 JAVA_MAXPERMSIZE=${JAVA_MAXPERMSIZE:=256}
 
 # Defaults Garbage Collector settings
-JAVA_GC=${JAVA_GC:="-XX:+UseConcMarkSweepGC
--XX:+CMSClassUnloadingEnabled"}
+# String dedup is useful in rudder: decrease heap size massively
+# AlwaysPreTouch: avoid page alloc during run, reduce latency at the price
+#                 of a bit more start-up time
+JAVA_GC=${JAVA_GC:="-XX:+UseG1GC
+-XX:+UseStringDeduplication
+-XX:+AlwaysPreTouch"}
+
+# GC log: file path, log level (jdk format, see:
+# https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-BE93ABDC-999C-4CB5-A88B-1994AAAC74D5)
+JAVA_GC_LOG_FILE=${JAVA_GC_LOG_FILE:="/var/log/rudder/webapp/jvm-gc.log"}
+JAVA_GC_LOG=${JAVA_GC_LOG:="gc=info,gc+cpu=info,gc+stringdedup=info"}
+JAVA_GC_LOG_ROTATE=${JAVA_GC_LOG_ROTATE:="filecount=5,filesize=50M"}
 
 # Java VM arguments
 JAVA_OPTIONS="${JAVA_OPTIONS}
 -server
 -Xms${JAVA_XMX}m -Xmx${JAVA_XMX}m
 ${JAVA_GC}
+-Xlog:${JAVA_GC_LOG}:file=${JAVA_GC_LOG_FILE}:utctime,pid,level,tags:${JAVA_GC_LOG_ROTATE}
 -Dfile.encoding=UTF-8
 -Drudder.configFile=/opt/rudder/etc/rudder-web.properties
 -Drudder.authFile=/opt/rudder/etc/rudder-users.xml

--- a/rudder-server/SOURCES/rudder-jetty.default
+++ b/rudder-server/SOURCES/rudder-jetty.default
@@ -23,19 +23,38 @@ JAVA_MAXPERMSIZE=256
 #
 #JAVA_OPTIONS=""
 
-# Java Garbage collector option
-# On large heap (6 Go or more) and loaded platforms, ConcurrentMarkSweep (default GC 
-# for Rudder) becomes inefficient and Rudder can experience long "stop the world" 
-# garbage collections.
-# To avoid that, you can use G1GC which leads to faster (or no) full GC on big heap,
-# at the prize of a less throughout and a need of some more memory to work 
-# efficiently (~10%).
-# You can also tune you GC option here.
+# Java garbage collector option
 #
+# By default, Rudder uses G1GC which is a very good general purpose GC on
+# all sizes of heap. The configuration should be good on most case.
+# But you can change GC or tune GC options here, like debug flags.
+# Documentation can be found here:
+# https://docs.oracle.com/en/java/javase/11/gctuning/garbage-first-garbage-collector-tuning.html
+#
+# For example, to keep defaut GC and options but add a hint on maximum
+# latency for full GC, you can use:
 #JAVA_GC="-XX:+UseG1GC
-#-XX:+UnlockExperimentalVMOptions
 #-XX:+UseStringDeduplication
-#-XX:MaxGCPauseMillis=500"
+#-XX:+AlwaysPreTouch
+#-XX:MaxGCPauseMillis=100"
+
+# Java garbage collector log options
+# You can specify alternatives options for JVM GC logs: file path, log level, rotation parameters.
+
+# Configure alternative log file path. Default is:
+#JAVA_GC_LOG_FILE="/var/log/rudder/webapp/jvm-gc.log"
+# For example for a specific file for debug logs:
+#JAVA_GC_LOG_FILE="/var/log/rudder/webapp/jvm-gc-debug.log"
+
+# Configure log level for debug. Default gives general info about GC timing:
+#JAVA_GC_LOG="gc=info,gc+cpu=info,gc+stringdedup=info"
+# The example below is insightful for debugging GC problem but verbose:
+#JAVA_GC_LOG="gc*=info,gc+heap=debug,gc+phases=debug,gc+ref*=debug,gc+ergo*=trace,gc+age*=trace"
+
+# Configure gc log rotation. Default is 5 files of 50M:
+#JAVA_GC_LOG_ROTATE="filecount=5,filesize=50M"
+# But it may be too little for debug, you may want less, bigger files:
+#JAVA_GC_LOG_ROTATE="filecount=3,filesize=100M"
 
 # Java VM location
 #
@@ -45,7 +64,7 @@ JAVA_MAXPERMSIZE=256
 # Please specify a JVM location here if the script is unable to find
 # it.
 #
-#JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
+#JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 #JAVA=java
 
 # Source variables from /opt/rudder/etc/rudder-jetty.conf

--- a/rudder-server/debian/conffiles
+++ b/rudder-server/debian/conffiles
@@ -1,4 +1,3 @@
-/opt/rudder/etc/rudder-jetty.conf
 /opt/rudder/etc/rudder-web.properties
 /opt/rudder/etc/rudder-users.xml
 /opt/rudder/etc/logback.xml


### PR DESCRIPTION
https://issues.rudder.io/issues/21151

Main changes: 
- use G1GC by default 
  - with string deduplication
  - and touch pages at launch
- add high level, not verbose GC info (always) in /var/log/rudder/webapp/jvm-gc.log (rotation: 5 files, 50M each)
- let user be able to override GC log level (with a suitable example for debug metrics in comments)
- notice in comment of the overridding file what is used by default