### PR TITLE
Fixes #21359: Add rhel9 support to packages -  openssl 3 only

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -90,6 +90,10 @@
 %define with_libcurl true
 %define with_openssl true
 %endif
+%if 0%{?rhel} && 0%{?rhel} >= 9
+# we embed openssl as system is too recent (openssl3) in this case
+%define with_openssl true
+%endif
 
 # Recent fedora has proper defaults
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21359