### PR TITLE
Fixes #21381: yum installs external-db instead of postgresql by default -  still the same

### DIFF
--- a/rudder-server/SPECS/rudder-server.spec
+++ b/rudder-server/SPECS/rudder-server.spec
@@ -86,7 +86,7 @@ Requires: %{apache}, %{apache_tools}, git-core, iproute, rsync, openssl, %{ldap_
 Requires: postgresql-server
 %else
 # rudder-external-db must prevent installation of postgresql-server
-Requires: (rudder-external-db or postgresql-server >= 10.3)
+Requires: (postgresql-server >= 10.3 unless rudder-external-db)
 %endif
 
 BuildRequires: gcc, rsync


### PR DESCRIPTION
https://issues.rudder.io/issues/21381