### PR TITLE
Fixes #21642: Uprading relay to 7.2 fails on ubuntu 22 - fix

### DIFF
--- a/rudder-relay/debian/postinst
+++ b/rudder-relay/debian/postinst
@@ -52,10 +52,10 @@ case "$1" in
       fi
 
       # sometimes (ubuntu22 ?) divert prevents the file to be present
-      if [ ! -f /opt/rudder/etc/rudder-networks-24.conf.distrib ]; then
+      if [ -f /opt/rudder/etc/rudder-networks-24.conf.distrib ]; then
         mv /opt/rudder/etc/rudder-networks-24.conf.distrib /opt/rudder/etc/rudder-networks-24.conf
       fi
-      if [ ! -f /opt/rudder/etc/rudder-networks-policy-server-24.conf.distrib ]; then
+      if [ -f /opt/rudder/etc/rudder-networks-policy-server-24.conf.distrib ]; then
         mv /opt/rudder/etc/rudder-networks-policy-server-24.conf.distrib /opt/rudder/etc/rudder-networks-policy-server-24.conf
       fi
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21642