### PR TITLE
Fixes #21674: Missing dependency on libpq for relay on centos9

### DIFF
--- a/rudder-relay/SPECS/rudder-relay.spec
+++ b/rudder-relay/SPECS/rudder-relay.spec
@@ -83,6 +83,10 @@ Requires: python3-policycoreutils policycoreutils-python-utils
 Requires: policycoreutils-python
 %endif
 
+%if 0%{?rhel} && 0%{?rhel} >= 9
+Requires: libpq
+%endif
+
 ## SLES
 %if 0%{?suse_version}
 Requires: pwdutils


### PR DESCRIPTION
https://issues.rudder.io/issues/21674