### PR TITLE
Fixes #21100: When cf-serverd starts it can kill an unrelated process

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/21100-lock-kill-cf-processes.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/21100-lock-kill-cf-processes.patch
@@ -1,0 +1,51 @@
+diff --git a/libpromises/locks.c b/libpromises/locks.c
+index 01407eda2..67918e99d 100644
+--- a/libpromises/locks.c
++++ b/libpromises/locks.c
+@@ -554,6 +554,33 @@ static void PromiseTypeString(char *dst, size_t dst_size, const Promise *pp)
+     }
+ }
+ 
++// returns true if pid points to a cfengine process
++static bool IsCfengineProcess(const int pid)
++{
++    // There is no /proc on windows
++#ifndef _WIN32
++    char procfile[PATH_MAX];
++    char cmd[PATH_MAX]; // we don't need the full ARG_MAX
++    snprintf(procfile, PATH_MAX, "/proc/%d/cmdline", pid);
++    FILE *f = fopen(procfile, "r");
++    if (f != NULL){
++        size_t size;
++        size = fread(cmd, sizeof(char), PATH_MAX, f);
++        if (size > 0){
++            if ('\n' == cmd[size-1]) {
++                cmd[size-1] = '\0';
++            }
++        }
++        fclose(f);
++        // cmd contains the process command path
++        char *name = basename(cmd);
++        return (strncmp("cf-", name, 3) == 0);
++    }
++#endif
++    // assume true if we don't know
++    return true;
++}
++
+ static bool KillLockHolder(const char *lock)
+ {
+     bool ret;
+@@ -587,6 +614,12 @@ static bool KillLockHolder(const char *lock)
+ 
+     CloseLock(dbp);
+ 
++    if (!IsCfengineProcess(lock_data.pid)) {
++        Log(LOG_LEVEL_VERBOSE,
++            "Lock holder with pid %d was replaced by a non cfengine process, do not try to kill it!, ", lock_data.pid);
++        return true;
++    }
++
+     if (GracefulTerminate(lock_data.pid, lock_data.process_start_time))
+     {
+         Log(LOG_LEVEL_INFO,


### PR DESCRIPTION
https://issues.rudder.io/issues/21100

Replacing previous PR: https://github.com/Normation/rudder-packages/pull/2597
