### PR TITLE
Fixes #22608: rudder-init replaces rudder-db password at postinst

### DIFF
--- a/rudder-server/SOURCES/rudder-init
+++ b/rudder-server/SOURCES/rudder-init
@@ -225,7 +225,6 @@ echo
 # Update the password file used by Rudder with random passwords
 echo -n "Updating Rudder password file with random passwords... "
 sed -i "s%RUDDER_WEBDAV_PASSWORD.*%RUDDER_WEBDAV_PASSWORD:$(dd if=/dev/urandom count=128 bs=1 2>&1 | md5sum | cut -b-20)%" ${RUDDER_OPT}/etc/rudder-passwords.conf
-sed -i "s%RUDDER_PSQL_PASSWORD.*%RUDDER_PSQL_PASSWORD:$(dd if=/dev/urandom count=128 bs=1 2>&1 | md5sum | cut -b-20)%" ${RUDDER_OPT}/etc/rudder-passwords.conf
 sed -i "s%RUDDER_OPENLDAP_BIND_PASSWORD.*%RUDDER_OPENLDAP_BIND_PASSWORD:$(dd if=/dev/urandom count=128 bs=1 2>&1 | md5sum | cut -b-20)%" ${RUDDER_OPT}/etc/rudder-passwords.conf
 echo " done."
 

--- a/rudder-server/SOURCES/rudder-server-postinst
+++ b/rudder-server/SOURCES/rudder-server-postinst
@@ -149,7 +149,7 @@ then
   # variable from ${EXTERNAL_DB_CONF}
   if [ "${DB_USER}" = "" ]; then
     USERNAME="rudder"
-    PASSWORD="Normation"
+    PASSWORD="$(dd if=/dev/urandom count=128 bs=1 2>&1 | md5sum | cut -b-20)"
 
     # Rudder user
     CHK_PG_USER=$(su postgres -c "psql -t -c \"select count(1) from pg_user where usename = '${USERNAME}'\"")
@@ -172,8 +172,8 @@ then
       POPULATE="true"
     fi
     # rudder-passwords default is not adapted to external db
-    sed -i "/^RUDDER_PSQL_PASSWORD/s/.*/RUDDER_PSQL_PASSWORD:${PASSWORD}/" /opt/rudder/etc/rudder-passwords.conf
   fi
+  sed -i "/^RUDDER_PSQL_PASSWORD/s/.*/RUDDER_PSQL_PASSWORD:${PASSWORD}/" /opt/rudder/etc/rudder-passwords.conf
 
   if [ "${POPULATE}" = "true" ]; then
     echo "${HOST}:5432:${DBNAME}:${USERNAME}:${PASSWORD}" > /root/.pgpass


### PR DESCRIPTION
https://issues.rudder.io/issues/22608