### PR TITLE
Fixes #22760: Add debian12 support to agent package -  missing openssl 1.1

### DIFF
--- a/rudder-agent/debian/rules
+++ b/rudder-agent/debian/rules
@@ -95,7 +95,8 @@ STRIP_OPT = --no-automatic-dbgsym
 endif
 # Debian 12
 ifeq (bookworm,$(OS_CODENAME))
-WITH = --with-lmdb
+# we embed openssl as system is too recent (openssl3) in this case
+WITH = --with-openssl --with-lmdb
 STRIP_OPT = --no-automatic-dbgsym
 endif
 


### PR DESCRIPTION
https://issues.rudder.io/issues/22760