### PR TITLE
Fixes #22786: git is a build dependency for rudder-server package -  sles git package name error

### DIFF
--- a/rudder-server/SPECS/dependencies
+++ b/rudder-server/SPECS/dependencies
@@ -1,4 +1,4 @@
-sles-15:gcc libopenssl-devel python3-devel rsync git-core git
+sles-15:gcc libopenssl-devel python3-devel rsync git-core
 rhel-7:gcc openssl-devel libtool-ltdl-devel python-devel selinux-policy-devel rsync openssl11-devel git
 rhel-8:gcc openssl-devel libtool-ltdl-devel python3-devel selinux-policy-devel rsync git
 rhel-9:gcc openssl-devel libtool-ltdl-devel python3-devel selinux-policy-devel rsync git


### PR DESCRIPTION
https://issues.rudder.io/issues/22786