### PR TITLE
Fixes #22942: accelerate rpm build when perl modules are already present -  Module include error

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -398,7 +398,7 @@ opt="${opt} --with-perl"
 %else
 perl -MModule::CoreList -e '' || cpan -f -T -i Module::CoreList < /dev/null || true
 perl -MYAML::Tiny -e '' || cpan -f -T -i YAML::Tiny < /dev/null
-perl -MModule::Install -e '' || cpan -f -T -i Module::Install < /dev/null
+perl -Minc::Module::Install -e '' || cpan -f -T -i Module::Install < /dev/null
 %endif
 
 # libattr libtool file is looked for in /lib64 but put in /usr/lib64 on RHEL3


### PR DESCRIPTION
https://issues.rudder.io/issues/22942