### PR TITLE
Fixes #22954: openssl 1.1.1 fails to build on debian 12 armhf

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -226,6 +226,9 @@ build-pcre: pcre-source
 	touch $@
 
 build-openssl: openssl-source @perl_DEP@
+	# recent gcc don't include fp in armv7a
+	cd openssl-source && sed -i "s/armv7-a/armv7-a+fp/g" util/perl/OpenSSL/config.pm
+	cd openssl-source && find crypto -type f | grep 'pl$$' | xargs sed -i "s/armv7-a/armv7-a+fp/g"
 	# openssl doesn't support CFLAGS (it overrides its own) so we must pass them in batch to configure
 	cd openssl-source && RELEASE="" @SSL_CONFIGURE@ -fPIC $(CFLAGS) $(LDFLAGS) $(PIE_LDFLAGS) --prefix=$(RUDDER_DIR) --openssldir=$(RUDDER_DIR)/openssl shared no-idea no-rc5 no-ssl3 no-dtls no-psk no-srp no-engine enable-egd
 	cd openssl-source && $(MAKE) depend


### PR DESCRIPTION
https://issues.rudder.io/issues/22954