### PR TITLE
Fixes #22995: gcc 12 option armv7-a+fp doesn't exist pre gcc 12

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -227,7 +227,7 @@ build-pcre: pcre-source
 
 build-openssl: openssl-source @perl_DEP@
 	# recent gcc don't include fp in armv7a
-	cd openssl-source && sed -i "s/armv7-a/armv7-a+fp/g" config
+	if [ "$(GCC_VERSION)" -ge 12 ]; then cd openssl-source && sed -i "s/armv7-a/armv7-a+fp/g" config; fi
 	# openssl doesn't support CFLAGS (it overrides its own) so we must pass them in batch to configure
 	cd openssl-source && RELEASE="" @SSL_CONFIGURE@ -fPIC $(CFLAGS) $(LDFLAGS) $(PIE_LDFLAGS) --prefix=$(RUDDER_DIR) --openssldir=$(RUDDER_DIR)/openssl shared no-idea no-rc5 no-ssl3 no-dtls no-psk no-srp no-engine enable-egd
 	cd openssl-source && $(MAKE) depend

--- a/rudder-agent/SOURCES/configure
+++ b/rudder-agent/SOURCES/configure
@@ -257,6 +257,9 @@ if [ "${USE_PIE}" = "true" ]; then
   test_cc "PIE" "-fPIE" "-pie"
 fi
 
+# detect gcc main version
+GCC_VERSION=$(gcc -dumpversion | cut -d. -f 1)
+
 # Macro for source getting in the makefile
 source_macro() {
   name="$1"
@@ -291,6 +294,8 @@ TAR = ${TAR}
 PATCH = ${PATCH}
 SED = ${SED}
 INSTALL = ${INSTALL}
+
+GCC_VERSION = ${GCC_VERSION}
 
 LMDB_MAKEFLAGS = ${LMDB_MAKEFLAGS}
 LMDB_LDFLAGS = ${LMDB_LDFLAGS}


### PR DESCRIPTION
https://issues.rudder.io/issues/22995