### PR TITLE
Fixes #23083: rhel7 server build should depends on python3-pip and python3

### DIFF
--- a/rudder-relay/SPECS/rudder-relay.spec
+++ b/rudder-relay/SPECS/rudder-relay.spec
@@ -113,6 +113,10 @@ BuildRequires: python3, python3-pip, python3-lxml, python3-requests
 Requires: python3, python3-lxml, python3-requests, python3-setuptools
 %endif
 
+%if 0%{?rhel} && 0%{?rhel} == 7
+BuildRequires: python3, python3-pip, python3-lxml, python3-requests
+%endif
+
 %description
 Rudder is an open source configuration management and audit solution.
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23083