### PR TITLE
Fixes #23388: Server install fails with postgresql encoding error

### DIFF
--- a/rudder-external-db/SOURCES/external-db.conf
+++ b/rudder-external-db/SOURCES/external-db.conf
@@ -11,7 +11,7 @@ DB_USER="rudder"
 DB_PASSWORD="xxx"
 
 # Postgresql database name, to create it ask your database administrator or use the following command
-#    su postgres -c "psql -q -c \"CREATE DATABASE ${DB_NAME} WITH OWNER = ${DB_USER} ENCODING = UTF8\""
+#    su postgres -c "psql -q -c \"CREATE DATABASE ${DB_NAME} TEMPLATE template0 WITH OWNER = ${DB_USER} ENCODING = UTF8\""
 DB_NAME="rudder"
 
 # - false to let rudder setup populate the database, provided that DB_USER has the permission to do so.

--- a/rudder-external-db/SOURCES/rudder-external-db-postinst
+++ b/rudder-external-db/SOURCES/rudder-external-db-postinst
@@ -19,7 +19,7 @@ DB_USER="rudder"
 DB_PASSWORD="xxx"
 
 # Postgresql database name, to create it ask your database administrator or use the following command
-#    su postgres -c "psql -q -c \"CREATE DATABASE ${DB_NAME} WITH OWNER = ${DB_USER} ENCODING = UTF8\""
+#    su postgres -c "psql -q -c \"CREATE DATABASE ${DB_NAME} TEMPLATE template0 WITH OWNER = ${DB_USER} ENCODING = UTF8\""
 DB_NAME="rudder"
 
 # - true if your database administrator has already created the database structure

--- a/rudder-server/SOURCES/rudder-server-postinst
+++ b/rudder-server/SOURCES/rudder-server-postinst
@@ -178,7 +178,7 @@ then
     CHK_PG_DB=$(su postgres -c "psql -t -c \"select count(1) from pg_catalog.pg_database where datname = '${DBNAME}'\"")
     if [ ${CHK_PG_DB} -eq 0 ]
     then
-      su postgres -c "psql -q -c \"CREATE DATABASE ${DBNAME} WITH OWNER = ${USERNAME} ENCODING = UTF8\"" >> ${LOG_FILE}
+      su postgres -c "psql -q -c \"CREATE DATABASE ${DBNAME} TEMPLATE template0 WITH OWNER = ${USERNAME} ENCODING = UTF8\"" >> ${LOG_FILE}
       POPULATE="true"
     fi
   else


### PR DESCRIPTION
https://issues.rudder.io/issues/23388

It looks like template1, the default template for creating database, has index and encoding can't be changed. So we need to ressort on `template0`, which is pristine. 
See: https://stackoverflow.com/a/28131347
And for the syntax: https://www.postgresql.org/docs/current/manage-ag-templatedbs.html