### PR TITLE
Fixes #23436: Rudder 8.0 cannot be installed on sles15sp4 due to dependency error

### DIFF
--- a/rudder-server/SPECS/rudder-server.spec
+++ b/rudder-server/SPECS/rudder-server.spec
@@ -112,7 +112,7 @@ BuildRequires: libopenssl-devel git-core
 %endif
 
 %if 0%{?sle_version} && 0%{?sle_version} >= 150000
-Requires: jre-headless >= 17
+Requires: java-17-openjdk-headless 
 %endif
 
 ## Python 3


### PR DESCRIPTION
https://issues.rudder.io/issues/23436