### PR TITLE
Fixes #23532: Missing dependency to perl-Digest-MD5 on 8.0 agents

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -154,7 +154,7 @@ Requires: perl-interpreter perl-lib perl-English perl-Memoize perl-Sys-Hostname 
 Requires: perl-interpreter perl-Memoize perl-JSON-PP perl-Math-BigInt perl-Digest-MD5
 %endif
 %if "%{with_perl}" == "false" && 0%{?rhel} && 0%{?rhel} < 8
-Requires: perl
+Requires: perl perl-Digest-MD5
 %endif
 %if "%{with_perl}" == "false" && 0%{?suse_version}
 Requires: perl


### PR DESCRIPTION
https://issues.rudder.io/issues/23532