### PR TITLE
Fixes #23608: Several low impact CVE in Jetty 10.0.12

### DIFF
--- a/rudder-server/SOURCES/Makefile
+++ b/rudder-server/SOURCES/Makefile
@@ -23,8 +23,8 @@ RUDDER_VERSION_TO_PACKAGE =
 RUDDER_MAJOR_VERSION := $(shell echo ${RUDDER_VERSION_TO_PACKAGE} | cut -d'.' -f 1-2)
 # Original URL: https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/${JETTY_RELEASE}/jetty-home-${JETTY_RELEASE}.tar.gz
 # Jetty 11 does not support the servlet version used by Lift, we stick to Jetty 10.
-JETTY_RELEASE = 10.0.12
-JETTY_SHA256 = b2ae3170a729365e05ba9da057aee5d2654d169912efec73cddc8381ac35d516
+JETTY_RELEASE = 10.0.17
+JETTY_SHA256 = 1ea4676b87c186d4603c044cbaf9b77d3180f1bd62e4b09e43e9ac941f1ac2df
 # Original URL: https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.2.tgz
 OPENLDAP_RELEASE = 2.6.3
 OPENLDAP_SHA256 = d2a2a1d71df3d77396b1c16ad7502e674df446e06072b0e5a4e941c3d06c0d46


### PR DESCRIPTION
https://issues.rudder.io/issues/23608

Jetty distrib downloaded from https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/10.0.17/jetty-home-10.0.17.tar.gz
Sha1 matching checked with https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/10.0.17/jetty-home-10.0.17.tar.gz.sha1
Computed sha256 with
```
❯ sha256sum jetty-home-10.0.17.tar.gz
1ea4676b87c186d4603c044cbaf9b77d3180f1bd62e4b09e43e9ac941f1ac2df  jetty-home-10.0.17.tar.gz
```