### PR TITLE
Fixes #23622: Some jetty patches don't apply to 10.0.17

### DIFF
--- a/rudder-server/SOURCES/patches/jetty/jetty-init-prevent-false-failed-starts.patch
+++ b/rudder-server/SOURCES/patches/jetty/jetty-init-prevent-false-failed-starts.patch
@@ -1,20 +1,6 @@
---- jetty/bin/jetty.sh	2017-10-20 21:09:54.213736038 +0200
-+++ jetty/bin/jetty.sh_5	2017-10-20 21:18:07.960397445 +0200
-@@ -137,11 +137,11 @@ started()
-   do
-     sleep 4
-     [ -z "$(tail -1 $1 | grep STARTED 2>/dev/null)" ] || return 0
-+
-     [ -z "$(tail -1 $1 | grep STOPPED 2>/dev/null)" ] || return 1
-     [ -z "$(tail -1 $1 | grep FAILED 2>/dev/null)" ] || return 1
--    local PID=$(cat "$2" 2>/dev/null) || return 1
--    kill -0 "$PID" 2>/dev/null || return 1
-     echo -n ". "
-+
-   done
-
-   return 1;
-@@ -483,6 +483,14 @@ case "$ACTION" in
+--- jetty/bin/jetty.sh
++++ jetty/bin/jetty.sh
+@@ -551,6 +551,14 @@ case "$ACTION" in
        exit
      fi
 
@@ -26,8 +12,7 @@
 +
 +    rm -f ${JETTY_STATE}
 +
-     if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1
+     if ! touch "$JETTY_PID"
      then
-       unset CH_USER
-
+       echo "** ERROR: Unable to touch file: $JETTY_PID"
 

--- a/rudder-server/SOURCES/patches/jetty/jetty-init-redirect-stderrout.patch
+++ b/rudder-server/SOURCES/patches/jetty/jetty-init-redirect-stderrout.patch
@@ -1,6 +1,6 @@
 --- jetty/bin/jetty.sh.orig	2018-08-29 09:38:33.684462836 +0200
 +++ jetty/bin/jetty.sh	2018-08-29 09:40:57.763691920 +0200
-@@ -317,6 +317,7 @@
+@@ -411,6 +411,7 @@ fi
  #####################################################
  # define start log location
  #####################################################
@@ -8,17 +8,20 @@
  if [ -z "$JETTY_START_LOG" ]
  then
    JETTY_START_LOG="$JETTY_RUN/$NAME-start.log"
-@@ -520,11 +521,11 @@
-         # FIXME: Broken solution: wordsplitting, pathname expansion, arbitrary command execution, etc.
+@@ -621,13 +622,13 @@ case "$ACTION" in
+         chown "$JETTY_USER" "$JETTY_PID"
          su - "$JETTY_USER" $SU_SHELL -c "
            cd \"$JETTY_BASE\"
--          exec ${RUN_CMD[*]} start-log-file=\"$JETTY_START_LOG\" > /dev/null &
-+          exec ${RUN_CMD[*]} start-log-file=\"$JETTY_START_LOG\" >${JETTY_START_LOG} 2>&1 &
-           disown \$!
-           echo \$! > \"$JETTY_PID\""
+-          echo ${RUN_ARGS[*]} --start-log-file=\"$JETTY_START_LOG\" | xargs ${JAVA} > /dev/null &
++          echo ${RUN_ARGS[*]} --start-log-file=\"$JETTY_START_LOG\" | xargs ${JAVA} >${JETTY_START_LOG} 2>&1 &
+           PID=\$!
+           disown \$PID"
+         (( DEBUG )) && echo "Starting: su shell (w/user $JETTY_USER) on PID $PID"
        else
--        "${RUN_CMD[@]}" > /dev/null &
-+        "${RUN_CMD[@]}" >${JETTY_START_LOG} 2>&1 &
-         disown $!
-         echo $! > "$JETTY_PID"
-       fi
+         # Startup if not switching users
+-        echo ${RUN_ARGS[*]} --start-log-file="${JETTY_START_LOG}" | xargs ${JAVA} > /dev/null &
++        echo ${RUN_ARGS[*]} --start-log-file="${JETTY_START_LOG}" | xargs ${JAVA} >${JETTY_START_LOG} 2>&1 &
+         PID=$!
+         disown $PID
+         (( DEBUG )) && echo "Starting: java command on PID $PID"
+

--- a/rudder-server/SOURCES/patches/jetty/jetty-init-sizecheck.patch
+++ b/rudder-server/SOURCES/patches/jetty/jetty-init-sizecheck.patch
@@ -1,9 +1,9 @@
---- jetty/bin/jetty.sh.orig	2018-08-28 17:55:24.439012644 +0200
-+++ jetty/bin/jetty.sh	2018-08-28 17:58:28.054678897 +0200
-@@ -154,9 +154,23 @@
+--- jetty/bin/jetty.sh.orig
++++ jetty/bin/jetty.sh
+@@ -222,9 +222,23 @@ readConfig()
    source "$1"
  }
- 
+
 +# Gets the memory size (Xmx+MaxPermSize) needed by Java megabytes as argument.
 +# Checks if there is enough available RAM + Swap to contain the JVM.
 +checkAvailableRam()
@@ -13,21 +13,21 @@
 +  TOTAL_MEM_NEEDED=$((((${1})*100)/90))
 +  TOTAL_MEM_AVAILABLE=$(($(free -m|awk '/^Mem:/{print $2}')+$(free -m|awk '/^Swap:/{print $2}')))
 +  if [ ${TOTAL_MEM_AVAILABLE} -le ${TOTAL_MEM_NEEDED} ]; then
-+    echo "WARNING: Not enough free memory to start Jetty (about ${TOTAL_MEM_NEEDED}MB are needed). Trying anyway, but the application is likely to fail."
++    echo "WARNING: Not enough free memory to start Jetty (about ${TOTAL_MEM_NEEDED}MB are needed). Trying anyway, but>
 +  fi
 +}
 +
  dumpEnv()
  {
-     echo "JAVA                  =  $JAVA"
-+    echo "JAVA_XMX              =  ${JAVA_XMX}"
-     echo "JAVA_OPTIONS          =  ${JAVA_OPTIONS[*]}"
-     echo "JETTY_HOME            =  $JETTY_HOME"
-     echo "JETTY_BASE            =  $JETTY_BASE"
-@@ -363,6 +377,12 @@
+   echo "JAVA                  =  $JAVA"
++  echo "JAVA_XMX              =  ${JAVA_XMX}"
+   echo "JAVA_OPTIONS          =  ${JAVA_OPTIONS[*]}"
+   echo "JETTY_HOME            =  $JETTY_HOME"
+   echo "JETTY_BASE            =  $JETTY_BASE"
+@@ -439,6 +453,12 @@ then
    done < "$JETTY_CONF"
  fi
- 
+
 +##################################################
 +# Set default JVM parameters, to be
 +# overridden by the configuration file
@@ -37,7 +37,7 @@
  ##################################################
  # Setup JAVA if unset
  ##################################################
-@@ -454,6 +474,9 @@
+@@ -549,6 +569,9 @@ case "$ACTION" in
      UMASK="0007"
      echo "Setting umask to ${UMASK}"
 
@@ -45,5 +45,6 @@
 +    # Metaspace is auomanaged in JDK8+. Rudder needs 150Mo of it.
 +    checkAvailableRam $((${JAVA_XMX}+150))
 
-     if (( NO_START )); then
-       echo "Not starting ${NAME} - NO_START=1";
+     # Startup from a service file
+     if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1
+

--- a/rudder-server/SOURCES/patches/jetty/jetty-init-sles.patch
+++ b/rudder-server/SOURCES/patches/jetty/jetty-init-sles.patch
@@ -1,21 +1,20 @@
---- jetty/bin/jetty-sles.sh	2014-11-21 18:18:10.761944184 +0100
-+++ jetty/bin/jetty-sles.sh	2014-11-21 18:17:40.897795646 +0100
-@@ -512,7 +512,7 @@
- 
-     rm -f ${JETTY_STATE}
- 
+--- jetty/bin/jetty-sles.sh
++++ jetty/bin/jetty-sles.sh
+@@ -609,7 +609,7 @@ case "$ACTION" in
+     checkAvailableRam $((${JAVA_XMX}+150))
+
+     # Startup from a service file
 -    if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1
 +    if [ "$START_STOP_DAEMON" = "1" ] && [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1
      then
        unset CH_USER
        if [ -n "$JETTY_USER" ]
-@@ -570,7 +570,7 @@
- 
+@@ -681,7 +681,7 @@ case "$ACTION" in
    stop)
      echo -n "Stopping Jetty: "
+     # Stop from a service file
 -    if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1; then
 +    if [ "$START_STOP_DAEMON" = "1" ] && [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1; then
        start-stop-daemon -K -p"$JETTY_PID" -d"$JETTY_HOME" -a "$JAVA" -s HUP
-       
-       TIMEOUT=30
 
+       TIMEOUT=30

--- a/rudder-server/SOURCES/patches/jetty/jetty-init-stop-fix.patch
+++ b/rudder-server/SOURCES/patches/jetty/jetty-init-stop-fix.patch
@@ -1,24 +1,14 @@
---- jetty/bin/jetty.sh	2012-11-05 15:44:19.000000000 +0100
-+++ jetty/bin/jetty.sh	2012-11-05 15:55:07.000000000 +0100
-@@ -503,6 +503,10 @@
+--- jetty/bin/jetty.sh	
++++ jetty/bin/jetty.sh	
+@@ -631,6 +631,10 @@ case "$ACTION" in
          if (( TIMEOUT-- == 0 )); then
            start-stop-daemon -K -p"$JETTY_PID" -d"$JETTY_HOME" -a "$JAVA" -s KILL
          fi
 +        if (( TIMEOUT < -10 )); then
-+          echo "Failed to stop Jetty. Giving up." 
++          echo "Failed to stop Jetty. Giving up."
 +          break
 +        fi
- 
+
          sleep 1
        done
-@@ -518,6 +522,10 @@
-         if (( TIMEOUT-- == 0 )); then
-           kill -KILL "$PID" 2>/dev/null
-         fi
-+        if (( TIMEOUT < -10 )); then
-+          echo "Failed to stop Jetty. Giving up." 
-+          break
-+        fi
- 
-         sleep 1
-       done
+

--- a/rudder-server/SOURCES/patches/jetty/jetty-init-stop-forcestop.patch
+++ b/rudder-server/SOURCES/patches/jetty/jetty-init-stop-forcestop.patch
@@ -1,9 +1,9 @@
---- jetty/bin/jetty.sh.orig	2015-12-07 19:25:57.456283949 +0100
-+++ jetty/bin/jetty.sh	2015-12-07 19:41:05.075633380 +0100
-@@ -164,6 +164,21 @@
+--- jetty/bin/jetty.sh.orig
++++ jetty/bin/jetty.sh
+@@ -273,6 +273,21 @@ done
  ACTION=$1
  shift
- 
+
 +# Detect the correct ps tool to use
 +ns=$(ps --no-header -o utsns --pid $$ 2>/dev/null || true)
 +if [ -e "/proc/bc/0" ]; then # we have openvz
@@ -11,10 +11,10 @@
 +    PS_COMMAND="/bin/vzps -E 0"
 +  else # use rudder provided vzps
 +    PS_COMMAND="/opt/rudder/bin/vzps.py -E 0"
-+  fi  
++  fi
 +elif [ -n "${ns}" ]; then # we have namespaces
 +  # the sed is here to prepend a fake user field that is removed by the -o option (it is never used)
-+  PS_COMMAND="eval ps --no-header -e -O utsns | grep -E '^[[:space:]]*[[:digit:]]*[[:space:]]+${ns}' | sed 's/^/user /'"
++  PS_COMMAND="eval ps --no-header -e -O utsns | grep -E '^[[:space:]]*[[:digit:]]*[[:space:]]+${ns}' | sed 's/^/user >
 +else # standard unix
 +  PS_COMMAND="ps -ef"
 +fi
@@ -22,28 +22,19 @@
  ##################################################
  # Read any configuration files
  ##################################################
-@@ -553,7 +568,7 @@
+@@ -663,7 +678,7 @@ case "$ACTION" in
            start-stop-daemon -K -p"$JETTY_PID" -d"$JETTY_HOME" -a "$JAVA" -s KILL
          fi
          if (( TIMEOUT < -10 )); then
--          echo "Failed to stop Jetty. Giving up." 
-+          echo "Failed to stop Jetty. Trying with force..." 
+-          echo "Failed to stop Jetty. Giving up."
++          echo "Failed to stop Jetty. Trying with force..."
            break
          fi
- 
-@@ -574,7 +589,7 @@
-           kill -KILL "$PID" 2>/dev/null
-         fi
-         if (( TIMEOUT < -10 )); then
--          echo "Failed to stop Jetty. Giving up." 
-+          echo "Failed to stop Jetty. Trying with force..." 
-           break
-         fi
- 
-@@ -587,6 +602,14 @@
-       echo OK
-     fi
- 
+
+@@ -683,6 +698,14 @@ case "$ACTION" in
+     rm -f "$JETTY_STATE"
+     echo OK
+
 +    # Ensure jetty is not still running
 +    PIDS=`${PS_COMMAND} | egrep "[j]ava .* /opt/rudder/jetty/start.jar" | awk '{print $2}'`
 +    for PID in ${PIDS}
@@ -53,5 +44,5 @@
 +    done
 +
      ;;
- 
+
    restart)

--- a/rudder-server/SOURCES/patches/jetty/jetty-init-umask.patch
+++ b/rudder-server/SOURCES/patches/jetty/jetty-init-umask.patch
@@ -1,22 +1,20 @@
 --- jetty/bin/jetty.sh.orig
 +++ jetty/bin/jetty.sh
-@@ -451,6 +451,9 @@ fi
- case "$ACTION" in
-   start)
+@@ -546,6 +546,9 @@ case "$ACTION" in
+     fi
+
      echo -n "Starting Jetty: "
 +    UMASK="0007"
 +    echo "Setting umask to ${UMASK}"
 +
 
-     if (( NO_START )); then
-       echo "Not starting ${NAME} - NO_START=1";
-@@ -465,7 +468,7 @@ case "$ACTION" in
-         CH_USER="--chuid $JETTY_USER"
+     # Startup from a service file
+     if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1
+@@ -557,6 +560,7 @@ case "$ACTION" in
        fi
 
--      start-stop-daemon --start $CH_USER \
-+      start-stop-daemon -k ${UMASK} --start $CH_USER \
+       echo ${RUN_ARGS[@]} --start-log-file="$JETTY_START_LOG" | xargs start-stop-daemon \
++       -k ${UMASK} \
+        --start $CH_USER \
         --pidfile "$JETTY_PID" \
         --chdir "$JETTY_BASE" \
-        --background \
-


### PR DESCRIPTION
https://issues.rudder.io/issues/23622

SO. Almost everything changed in the start script between 10.0.12 and 10.0.17. This is unfortunate and feels risky. 

Still, I was able to port *almost* all patches. There is one that I don't understand: `jetty-init-prevent-false-failed-starts.patch`

The other ones are mainly change in place, sometime a lot but it seems ok. 