### PR TITLE
Fixes #23649: Bump to openssl 3.0.12

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -37,8 +37,8 @@ pcre_RELEASE = 8.45
 pcre_SHA256 = 4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09
 # We follow LTS releases
 # Original URL: https://www.openssl.org/source/openssl-$(OPENSSL_RELEASE).tar.gz
-openssl_RELEASE = 3.0.11
-openssl_SHA256 = b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55
+openssl_RELEASE = 3.0.12
+openssl_SHA256 = f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61
 # Original URL: http://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz
 libyaml_RELEASE = 0.2.5
 libyaml_SHA256 = c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4


### PR DESCRIPTION
https://issues.rudder.io/issues/23649