### PR TITLE
Fixes #23635: Agent Pre-established trust not working with Rudder 8.0 agent RHEL 7 on CentOS 7

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -440,6 +440,7 @@ install-agent: build cleanup-build rudder-agent rudder-agent.cron debug-script/r
 	@IF_libcurl@ cp -rp dependencies/opt/rudder/bin/curl $(DESTDIR)/opt/rudder/bin/
 	@IF_jq@ cp -rp dependencies/opt/rudder/bin/jq $(DESTDIR)/opt/rudder/bin/
 	@IF_augeas@ cp -rp dependencies/opt/rudder/bin/aug* $(DESTDIR)/opt/rudder/bin/
+	@IF_openssl@ cp -rp dependencies/opt/rudder/bin/openssl $(DESTDIR)/opt/rudder/bin/
 
 	mkdir -p $(DESTDIR)/opt/rudder/share/man/man8
 	cd $(DESTDIR)/opt/rudder/bin && for binary in cf-agent cf-promises cf-key cf-execd cf-serverd cf-net cf-runagent; do \


### PR DESCRIPTION
https://issues.rudder.io/issues/23635