### PR TITLE
Fixes #24359: Typo in rudder-sign openssl 3 signing regex

### DIFF
--- a/rudder-agent/SOURCES/rudder-sign
+++ b/rudder-agent/SOURCES/rudder-sign
@@ -76,7 +76,7 @@ EOF
 elif [ "${VERSION}" = "1.1" ]
 then
   SHORT_PUBKEY=`sed '/---/d' "${PUBKEY}" | tr -d '\n'`
-  HASH_VALUE=`openssl "${HASH}" "${FILE}" | sed "s/(.*)= \\(.*\\)/\\1/"`
+  HASH_VALUE=`openssl "${HASH}" "${FILE}" | sed "s/.*(.*)= \\(.*\\)/\\1/"`
   # Create a signature FILE
   cat > "${FILE}.sign" <<EOF
 header=rudder-signature-v1


### PR DESCRIPTION
https://issues.rudder.io/issues/24359