### PR TITLE
Fixes #24449: Move plugins postupgrade after webapp restart

### DIFF
--- a/rudder-server/SOURCES/rudder-server-postinst
+++ b/rudder-server/SOURCES/rudder-server-postinst
@@ -322,15 +322,15 @@ echo "Running upgrade script" >> ${LOG_FILE}
 # Adjust permissions on /var/rudder/configuration-repository
 /opt/rudder/bin/rudder-fix-repository-permissions >> ${LOG_FILE}
 
-echo "Running plugins upgrade scripts" >> ${LOG_FILE}
-rudder package rudder-postupgrade  || true
-
 echo "Restoring file ACLs" >> ${LOG_FILE}
 cd /
 [ -f /tmp/rudder-hooks-upgrade ] && setfacl --restore=/tmp/rudder-hooks-upgrade
 
 # Restart the webapp
 systemctl restart rudder-jetty >> ${LOG_FILE} || true
+
+echo "Running plugins upgrade scripts" >> ${LOG_FILE}
+rudder package rudder-postupgrade  || true
 
 ## Make sure everything is ok
 if [ "${RUDDER_FIRST_INSTALL}" = "true" ]; then


### PR DESCRIPTION
https://issues.rudder.io/issues/24449

Not sure if it will fix openscap upgrade problems (it could if the webapp was left in a broken state by previous upgrade steps) but at least I think it makes more sense.