### PR TITLE
Fixes #25252: rudder-cf-serverd was stopped on the server, and nothing restarted it

### DIFF
--- a/rudder-agent/SOURCES/systemd/rudder-cf-execd.service
+++ b/rudder-agent/SOURCES/systemd/rudder-cf-execd.service
@@ -11,6 +11,7 @@ Environment=VERBOSITY_OPTION=
 ExecStart=/opt/rudder/bin/cf-execd --no-fork $VERBOSITY_OPTION
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
+RestartSec=10
 KillMode=process
 
 [Install]

--- a/rudder-agent/SOURCES/systemd/rudder-cf-serverd.service
+++ b/rudder-agent/SOURCES/systemd/rudder-cf-serverd.service
@@ -11,6 +11,7 @@ Environment=VERBOSITY_OPTION=--inform
 ExecStart=/opt/rudder/bin/cf-serverd --graceful-detach=600 --no-fork $VERBOSITY_OPTION
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
+RestartSec=10
 NotifyAccess=main
 KillMode=process
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25252

The default value of 100ms might have prevented correct restart. Let's use the same value as upstream (https://github.com/Normation/rudder-packages/blob/master/rudder-agent/SOURCES/systemd/rudder-cf-serverd.service)