### PR TITLE
Fixes #26034: Installation of RHEL 9 flavors (alma, oraclelinux) fails with postgresql.service: Failed with result 'exit-code'

### DIFF
--- a/rudder-server/SOURCES/rudder-server-postinst
+++ b/rudder-server/SOURCES/rudder-server-postinst
@@ -97,6 +97,7 @@ then
       echo "Initializing postgresql db (initdb)" >> ${LOG_FILE}
       ${POSTGRESQL_SETUP} initdb >> ${LOG_FILE} 2>&1
     fi
+    systemd-tmpfiles --create
     systemctl start ${POSTGRESQL_SERVICE_NAME} >> ${LOG_FILE}
   fi
 


### PR DESCRIPTION
https://issues.rudder.io/issues/26034