### PR TITLE
Fixes #26809: Agent fails to build without embedded augeas

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -215,17 +215,18 @@ ifneq (false,$(USE_RUST))
 endif
 ifneq (false,$(USE_BINDGEN))
 	# The deps versions are in the Cargo.lock in the repo root
-	#
 	# pkg-config hack for augeas: the pkg-config file points to the prefix dir (/opt/rudder), but we build against DESTDIR.
+	# needed because we cannot comment inside a multiline command
+@UNLESS_augeas@AUGEAS_DO=true
 	DEPS_SOURCE_SHA=$$(ls -1 rudder-sources/rudder/Cargo.* | sort | xargs openssl dgst -sha256 | openssl dgst -sha256 | awk '{print $$2}') ;\
 	AGENT_SOURCE_SHA=$$(find rudder-sources/rudder/policies -type f | sort | xargs openssl dgst -sha256 | openssl dgst -sha256 | awk '{print $$2}') ;\
 	CACHE_SHA=$$(echo "$$DEPS_SOURCE_SHA $$AGENT_SOURCE_SHA" | openssl dgst -sha256 | awk '{print $$2}') ;\
 	AGENT_CACHE_PARAMETERS="--with-env name=rudder-agent-augeas source=$${CACHE_SHA}}" ;\
 	if ! ../../build-caching get $(RUST_TARGET)/ $${AGENT_CACHE_PARAMETERS}; then \
-		cp $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc.back; \
-		sed -i 's@^prefix=.*@prefix=$(CURDIR)/dependencies$(RUDDER_DIR)@' $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc; \
+		$(AUGEAS_DO) cp $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc.back; \
+		$(AUGEAS_DO) sed -i 's@^prefix=.*@prefix=$(CURDIR)/dependencies$(RUDDER_DIR)@' $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc; \
 		cd $(CURDIR)/rudder-sources/rudder/policies/module-types/augeas && make RUSTFLAGS="$${RUSTFLAGS} -C link-args=-Wl,-rpath,$(RUDDER_DIR)/lib" PKG_CONFIG_PATH="$(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/" build || exit 1 ;\
-		cp $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc.back $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc; \
+		$(AUGEAS_DO) cp $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc.back $(CURDIR)/dependencies$(RUDDER_DIR)/lib/pkgconfig/augeas.pc; \
 		cd $(CURDIR); ../../build-caching put $(RUST_TARGET)/ $${AGENT_CACHE_PARAMETERS} || true ;\
 	fi
 endif


### PR DESCRIPTION
https://issues.rudder.io/issues/26809

Replacing previous PR: https://github.com/Normation/rudder-packages/pull/2984
