### PR TITLE
Fixes #26833: Agent fails to build without embedded augeas -  syntax error on --without-augeas

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -201,6 +201,7 @@ ifneq (false,$(USE_APT))
 CARGO_FEATURES_SU="apt"
 endif
 
+@UNLESS_augeas@AUGEAS_DO=true
 build-agent: @augeas_DEP@ rudder-sources
 ifneq (false,$(USE_RUST))
 	# The deps versions are in the Cargo.lock in the repo root
@@ -217,7 +218,6 @@ ifneq (false,$(USE_BINDGEN))
 	# The deps versions are in the Cargo.lock in the repo root
 	# pkg-config hack for augeas: the pkg-config file points to the prefix dir (/opt/rudder), but we build against DESTDIR.
 	# needed because we cannot comment inside a multiline command
-@UNLESS_augeas@AUGEAS_DO=true
 	DEPS_SOURCE_SHA=$$(ls -1 rudder-sources/rudder/Cargo.* | sort | xargs openssl dgst -sha256 | openssl dgst -sha256 | awk '{print $$2}') ;\
 	AGENT_SOURCE_SHA=$$(find rudder-sources/rudder/policies -type f | sort | xargs openssl dgst -sha256 | openssl dgst -sha256 | awk '{print $$2}') ;\
 	CACHE_SHA=$$(echo "$$DEPS_SOURCE_SHA $$AGENT_SOURCE_SHA" | openssl dgst -sha256 | awk '{print $$2}') ;\


### PR DESCRIPTION
https://issues.rudder.io/issues/26833