### PR TITLE
Fixes #26895: Remove two useless “chown root” that prevents building the agent without being root

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -321,9 +321,6 @@ ifeq ($(INSTALL),ginstall)
 endif
 	cd fusion-source && PERL_MM_USE_DEFAULT=1 $(PERL) -I. Makefile.PL --default PREFIX=$(RUDDER_DIR)
 	cd fusion-source && $(MAKE) install DESTDIR=$(CURDIR)/fusion
-	# bug in fusion installer that doesn't set the right owner to some files
-	chown root fusion/opt/rudder/share/fusioninventory
-	chown root fusion/opt/rudder/share/fusioninventory/html
 
 
 ##########################################


### PR DESCRIPTION
https://issues.rudder.io/issues/26895

Replacing previous PR: https://github.com/Normation/rudder-packages/pull/2989
