### PR TITLE
Fixes #26915: CFengine patch for proper identification of ArchLinux and Manjaro Linux nodes

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/26915-cfengine-manjaro-os.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/26915-cfengine-manjaro-os.patch
@@ -1,0 +1,77 @@
+diff --git a/libenv/sysinfo.c b/libenv/sysinfo.c
+index 3c295111a..b579d0c61 100644
+--- a/libenv/sysinfo.c
++++ b/libenv/sysinfo.c
+@@ -1379,7 +1379,12 @@ static void OSClasses(EvalContext *ctx)
+         SetFlavor(ctx, "gentoo");
+     }
+ 
+-    if (stat("/etc/arch-release", &statbuf) != -1)
++    if (stat("/etc/manjaro-release", &statbuf) != -1)
++    {
++        Log(LOG_LEVEL_VERBOSE, "This appears to be a Manjaro Linux system.");
++        SetFlavor(ctx, "manjaro");
++    }
++    else if (stat("/etc/arch-release", &statbuf) != -1)
+     {
+         Log(LOG_LEVEL_VERBOSE, "This appears to be an Arch Linux system.");
+         SetFlavor(ctx, "archlinux");
+@@ -3654,6 +3659,12 @@ static void SysOSNameHuman(EvalContext *ctx)
+                                       "Amazon", CF_DATA_TYPE_STRING,
+                                       "source=agent,derived-from=amazon_linux");
+     }
++    else if (EvalContextClassGet(ctx, NULL, "manjaro") != NULL)
++    {
++        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
++                                      "Manjaro", CF_DATA_TYPE_STRING,
++                                      "source=agent,derived-from=arch");
++    }
+     else if (EvalContextClassGet(ctx, NULL, "arch") != NULL)
+     {
+         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
+diff --git a/tests/acceptance/01_vars/02_functions/001.cf b/tests/acceptance/01_vars/02_functions/001.cf
+index 58ddb48c1..69994df3f 100644
+--- a/tests/acceptance/01_vars/02_functions/001.cf
++++ b/tests/acceptance/01_vars/02_functions/001.cf
+@@ -34,11 +34,11 @@ bundle agent test
+     !darwin::
+       "uid_bin" int => getuid("bin");
+ 
+-    (linux.!archlinux.!SuSE.!redhat.!gentoo)|solaris|hpux|aix::
++    (linux.!manjaro.!archlinux.!SuSE.!redhat.!gentoo)|solaris|hpux|aix::
+       "num_root" int => "0";
+       "num_daemon" int => "1";
+       "num_bin" int => "2";
+-    archlinux|SuSE|redhat|gentoo::
++    manjaro|archlinux|SuSE|redhat|gentoo::
+       "num_root" int => "0";
+       "num_daemon" int => "2";
+       "num_bin" int => "1";
+diff --git a/tests/acceptance/01_vars/02_functions/002.cf b/tests/acceptance/01_vars/02_functions/002.cf
+index 22edc1a95..40e360abd 100644
+--- a/tests/acceptance/01_vars/02_functions/002.cf
++++ b/tests/acceptance/01_vars/02_functions/002.cf
+@@ -47,9 +47,9 @@ bundle agent test
+     !linux.!freebsd.!solaris.!darwin.!openbsd.!hpux.!aix::
+       "gid_0" string => "fixme";
+ 
+-    archlinux|SuSE|redhat|gentoo::
++    manjaro|archlinux|SuSE|redhat|gentoo::
+       "num_daemon" int => "2";
+-    (linux.!archlinux.!SuSE.!redhat.!gentoo)|freebsd|darwin|openbsd::
++    (linux.!manjaro.!archlinux.!SuSE.!redhat.!gentoo)|freebsd|darwin|openbsd::
+       "num_daemon" int => "1";
+     solaris::
+       "num_daemon" int => "12";
+diff --git a/tests/acceptance/02_classes/01_basic/expected_os_classes.cf b/tests/acceptance/02_classes/01_basic/expected_os_classes.cf
+index 020f4a189..bda5118bf 100644
+--- a/tests/acceptance/02_classes/01_basic/expected_os_classes.cf
++++ b/tests/acceptance/02_classes/01_basic/expected_os_classes.cf
+@@ -26,6 +26,7 @@ bundle agent check
+                          "hpux",
+                          "suse",
+                          "opensuse",
++                         "manjaro",
+                          "archlinux",
+                          "windows",
+                          "freebsd",


### PR DESCRIPTION
https://issues.rudder.io/issues/26915