### PR TITLE
Fixes #25491: perl-Digest-MD5 is missing from dependencies in RHEL6

### DIFF
--- a/rudder-agent/SPECS/rudder-agent.spec
+++ b/rudder-agent/SPECS/rudder-agent.spec
@@ -153,8 +153,11 @@ Requires: perl-interpreter perl-lib perl-English perl-Memoize perl-Sys-Hostname 
 %if "%{with_perl}" == "false" && 0%{?rhel} == 8
 Requires: perl-interpreter perl-Memoize perl-JSON-PP perl-Math-BigInt perl-Digest-MD5
 %endif
-%if "%{with_perl}" == "false" && 0%{?rhel} && 0%{?rhel} < 8
+%if "%{with_perl}" == "false" && 0%{?rhel} && 0%{?rhel} == 7 
 Requires: perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version)) perl-Digest-MD5
+%endif
+%if "%{with_perl}" == "false" && 0%{?rhel} && 0%{?rhel} < 7
+Requires: perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 %endif
 %if "%{with_perl}" == "false" && 0%{?suse_version}
 Requires: perl = %{perl_version}


### PR DESCRIPTION
https://issues.rudder.io/issues/25491