### PR TITLE
Fixes #27413: Upload large file in technique resources or file download returns error

### DIFF
--- a/rudder-server/SOURCES/rudder-apache-webapp-ssl.conf
+++ b/rudder-server/SOURCES/rudder-apache-webapp-ssl.conf
@@ -62,6 +62,9 @@ ProxyPass         "/rudder" "http://localhost:8080/rudder" retry=0
 ProxyPassReverse  "/rudder" "http://localhost:8080/rudder"
 ProxyRequests     Off
 
+# Jetty may terminate abruptly for big uploads
+SetEnv proxy-nokeepalive 1
+
 # Local reverse proxy authorization override
 # Most unix distribution deny proxy by default (ie /etc/apache2/mods-enabled/proxy.conf in Ubuntu)
 <Proxy http://localhost:8080/rudder*>


### PR DESCRIPTION
https://issues.rudder.io/issues/27413

https://httpd.apache.org/docs/2.4/en/mod/mod_proxy_http.html#env : I tried the different kinds of env variables that could explain the interrupted upload, and `proxy-nokeepalive` seems to be the only one fixing it

> Forces the proxy to close the backend connection after each request.

:arrow_right:  that explains why Jetty terminates but apache does not seem to understand why (e.g. when uploading a >8MB file, see https://github.com/Normation/rudder/pull/5828/files#r1728452973) 