### PR TITLE
Fixes #28751: librsync file end up in lib64

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -264,7 +264,7 @@ build-libcurl: libcurl-source @openssl_DEP@
 	touch $@
 
 build-librsync: librsync-source
-	cd librsync-source && cmake -DCMAKE_INSTALL_PREFIX=$(RUDDER_DIR) -DCMAKE_BUILD_TYPE=Release .
+	cd librsync-source && cmake -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_PREFIX=$(RUDDER_DIR) -DCMAKE_BUILD_TYPE=Release .
 	cd librsync-source && $(MAKE)
 	cd librsync-source && $(MAKE) install DESTDIR=$(CURDIR)/dependencies
 


### PR DESCRIPTION
https://issues.rudder.io/issues/28751

It actually depends on the platform behavior (via GNUInstalDirs), but we have an hardcoded path in Rudder, let's stick to that.