### PR TITLE
Fixes #28792: Missing libcrypt-dev build dependency on Ubuntu

### DIFF
--- a/rudder-agent/debian/control
+++ b/rudder-agent/debian/control
@@ -2,7 +2,7 @@ Source: rudder-agent
 Section: admin
 Priority: optional
 Maintainer: Rudder Team <dev@rudder.io>
-Build-Depends: debhelper (>= 11), bison, gcc, flex, autoconf, automake, libtool, libpcre2-dev, libpam0g-dev, ca-certificates, perl, lsb-release, libyaml-dev, libacl1-dev, python | python3, rsync, libssl-dev, libcurl4-openssl-dev, libmodule-corelist-perl, libmodule-install-perl, libreadline-dev, pkg-config, libsystemd-dev, libapt-pkg-dev, clang
+Build-Depends: debhelper (>= 11), bison, gcc, flex, autoconf, automake, libtool, libpcre2-dev, libpam0g-dev, ca-certificates, perl, lsb-release, libyaml-dev, libacl1-dev, python | python3, rsync, libssl-dev, libcurl4-openssl-dev, libmodule-corelist-perl, libmodule-install-perl, libreadline-dev, pkg-config, libsystemd-dev, libapt-pkg-dev, clang, libcrypt-dev
 Standards-Version: 4.6.1
 Homepage: https://www.rudder.io
 


### PR DESCRIPTION
https://issues.rudder.io/issues/28792