### PR TITLE
Fixes #28838: Update our version of jetty to 12.1.8

### DIFF
--- a/rudder-server/SOURCES/Makefile
+++ b/rudder-server/SOURCES/Makefile
@@ -22,8 +22,8 @@ SHELL = /bin/bash
 RUDDER_VERSION_TO_PACKAGE =
 RUDDER_MAJOR_VERSION := $(shell echo ${RUDDER_VERSION_TO_PACKAGE} | cut -d'.' -f 1-2)
 # Original URL: https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/${JETTY_RELEASE}/jetty-home-${JETTY_RELEASE}.tar.gz
-JETTY_RELEASE = 12.1.4
-JETTY_SHA256 = 9e8e467b8a5d60a37eb57509ab5d112824ed44b14d773e6c3aec3aa3e6715dd6
+JETTY_RELEASE = 12.1.8
+JETTY_SHA256 = 1fd7da2356bf1a5289ef81d841cdf39e7c561336ad00223cd9033265ee59ea04
 # Original URL: https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.2.tgz
 OPENLDAP_RELEASE = 2.6.10
 OPENLDAP_SHA256 = c065f04aad42737aebd60b2fe4939704ac844266bc0aeaa1609f0cad987be516


### PR DESCRIPTION
https://issues.rudder.io/issues/28838

Jetty release added to the correct place in repo and sha256 cheked. 
Everything seems to work in a local installation :
- `make jetty` is OK
- replacing `/opt/rudder/jetty` by jetty 12.1.8 content works

Everything is easier since we don't have special patchs and the like :tada:  