### PR TITLE
Fixes #29062: Make the generated passwords longer

### DIFF
--- a/rudder-server/SOURCES/rudder-init
+++ b/rudder-server/SOURCES/rudder-init
@@ -224,8 +224,8 @@ echo
 
 # Update the password file used by Rudder with random passwords
 echo -n "Updating Rudder password file with random passwords... "
-sed -i "s%RUDDER_WEBDAV_PASSWORD.*%RUDDER_WEBDAV_PASSWORD:$(dd if=/dev/urandom count=128 bs=1 2>&1 | md5sum | cut -b-20)%" ${RUDDER_OPT}/etc/rudder-passwords.conf
-sed -i "s%RUDDER_OPENLDAP_BIND_PASSWORD.*%RUDDER_OPENLDAP_BIND_PASSWORD:$(dd if=/dev/urandom count=128 bs=1 2>&1 | md5sum | cut -b-20)%" ${RUDDER_OPT}/etc/rudder-passwords.conf
+sed -i "s%RUDDER_WEBDAV_PASSWORD.*%RUDDER_WEBDAV_PASSWORD:$(dd if=/dev/urandom count=128 bs=1 2>&1 | sha256sum | cut -b-30)%" ${RUDDER_OPT}/etc/rudder-passwords.conf
+sed -i "s%RUDDER_OPENLDAP_BIND_PASSWORD.*%RUDDER_OPENLDAP_BIND_PASSWORD:$(dd if=/dev/urandom count=128 bs=1 2>&1 | sha256sum | cut -b-30)%" ${RUDDER_OPT}/etc/rudder-passwords.conf
 echo " done."
 
 # Delete temp files

--- a/rudder-server/SOURCES/rudder-server-postinst
+++ b/rudder-server/SOURCES/rudder-server-postinst
@@ -154,7 +154,7 @@ then
   POPULATE="false"
 
   USERNAME="rudder"
-  PASSWORD="$(dd if=/dev/urandom count=128 bs=1 2>&1 | md5sum | cut -b-20)"
+  PASSWORD="$(dd if=/dev/urandom count=128 bs=1 2>&1 | sha256sum | cut -b-30)"
 
   # Rudder user
   CHK_PG_USER=$(su postgres -s /bin/sh -c "psql -t -c \"select count(1) from pg_user where usename = '${USERNAME}'\"")


### PR DESCRIPTION
https://issues.rudder.io/issues/29062

* entropy 80bits -> 120bits
* don't use md5 as it looks bad, even if ok here as we use mainly use it for hexa output