### PR TITLE
Fixes #29084: dpkg source package name is wrong in inventory

### DIFF
--- a/rudder-agent/SOURCES/patches/fusioninventory/18318-add-source-package-debian.patch
+++ b/rudder-agent/SOURCES/patches/fusioninventory/18318-add-source-package-debian.patch
@@ -19,8 +19,8 @@ diff --color -ruN fusion-source.bak/lib/FusionInventory/Agent/Task/Inventory/Gen
          '${Section}\t' .
 -        '${Status}\n' .
 +        '${Status}\t' .
-+        '${Source}\t' .
-+        '${source:Version}\n' .
++        '${Source:Package}\t' .
++        '${Source:Version}\n' .
          '\'';
  
      my $packages = _getPackagesList(


### PR DESCRIPTION
https://issues.rudder.io/issues/29084