### PR TITLE
Fixes #29117: Bump curl to 8.21.0

### DIFF
--- a/rudder-agent/SOURCES/Makefile.in
+++ b/rudder-agent/SOURCES/Makefile.in
@@ -46,8 +46,8 @@ libxml2_SHA256 = e8655291ee6f20c8abf57854ff0709e8b178c619001a4d850002aafc81885e1
 pcre2_RELEASE = 10.44
 pcre2_SHA256 = 86b9cb0aa3bcb7994faa88018292bc704cdbb708e785f7c74352ff6ea7d3175b
 # Original URL: https://curl.haxx.se/download/curl-7.58.0.tar.gz
-libcurl_RELEASE = 8.20.0
-libcurl_SHA256 = fc5819cad3f9f5482669adcdc49a782c15f36d2a0715b395b06d9173593d2dc0
+libcurl_RELEASE = 8.21.0
+libcurl_SHA256 = d9b327997999045a24cda50f3983e69e51c516bd8be6ef9842fc7f99135e33bb
 # Original URL: https://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz
 readline_RELEASE = 8.2
 readline_SHA256 = 3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35


### PR DESCRIPTION
https://issues.rudder.io/issues/29117