### PR TITLE
Fixes #29171: CFengine patch for proper identification of Arch Linux ARM nodes

### DIFF
--- a/rudder-agent/SOURCES/patches/cfengine/29171-archarm-os.patch
+++ b/rudder-agent/SOURCES/patches/cfengine/29171-archarm-os.patch
@@ -1,0 +1,15 @@
+--- a/libenv/sysinfo.c
++++ b/libenv/sysinfo.c
+@@ -3526,6 +3526,12 @@
+                                       "Arch", CF_DATA_TYPE_STRING,
+                                       "source=agent,derived-from=arch");
+     }
++    else if (EvalContextClassGet(ctx, NULL, "archarm") != NULL)
++    {
++        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
++                                      "Arch", CF_DATA_TYPE_STRING,
++                                      "source=agent,derived-from=archarm");
++    }
+     else if (EvalContextClassGet(ctx, NULL, "postmarketos") != NULL)
+     {
+         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,


### PR DESCRIPTION
https://issues.rudder.io/issues/29171