### PR TITLE
Fixes #29277: webapp non-root: fix broken rpm packaging

### DIFF
--- a/rudder-server/SOURCES/Makefile
+++ b/rudder-server/SOURCES/Makefile
@@ -239,6 +239,8 @@ install: build rudder-server-version initial-promises initial-ncf
 
 	touch $@
 
+	mkdir -p $(DESTDIR)/var/rudder/lib/webapp
+
 clean:
 	rm -rf rudder-users.xml
 	rm -rf maven/


### PR DESCRIPTION
https://issues.rudder.io/issues/29277