### PR TITLE
Fixes #29466: Jetty restart in postinst fails in RPM packages on 9.0 -> 9.1

### DIFF
--- a/rudder-server/SOURCES/rudder-server-postinst
+++ b/rudder-server/SOURCES/rudder-server-postinst
@@ -344,6 +344,10 @@ HOOKS_ACL_FILE="/var/rudder/tmp/upgrade-hooks-acl"
 [ -f "${HOOKS_ACL_FILE}" ] && setfacl --restore="${HOOKS_ACL_FILE}"
 rm -f "${HOOKS_ACL_FILE}" /tmp/rudder-hooks-upgrade
 
+# On upgrade from pre-9.1 with RPM, old Jetty 11 files are still there, preventing Jetty 12 from starting.
+# The right fix is probably not to try to start jetty before posttrans, but for now we make the minimal change to allow it to start.
+rm -f /opt/rudder/etc/rudder-jetty-base/start.ini
+
 # Restart the webapp
 systemctl restart rudder-slapd >> ${LOG_FILE} || true
 systemctl restart rudder-jetty >> ${LOG_FILE} || true


### PR DESCRIPTION
https://issues.rudder.io/issues/29466